### PR TITLE
Port KeyQuest curriculum to gtypist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,75 @@
 # gtypist-lesson
-Touch type practice script
 
-## Desctiption
-"Gtypist" is typing practice software that runs on the terminal.
-(Official site : https://www.gnu.org/software/gtypist/)
-This script file is a practice script for "gtypist".
+Touch typing practice scripts for [GNU Typist](https://www.gnu.org/software/gtypist/).
 
-## Usage
-Execute the following on the command line.
+This repository contains two terminal lesson scripts:
+
+- `xion.typ`: the original weak-finger etude collection.
+- `keyquest.typ`: a GNU Typist adaptation of the first 28 implemented KeyQuest lessons.
+
+## Requirements
+
+Install GNU Typist before running these scripts.
+
+### Debian / Ubuntu
+
+```sh
+sudo apt install gtypist
 ```
+
+### macOS
+
+```sh
+brew install gtypist
+```
+
+## Quick Start
+
+Run the KeyQuest journey directly from this repository:
+
+```sh
+gtypist keyquest.typ
+```
+
+Run the original weak-finger etudes:
+
+```sh
 gtypist xion.typ
 ```
 
-## Install
-Register the path where this script file is installed in the environment variable "$ GTYPIST_PATH".
-I think it is good to write the following in ".bash_profile", ".bashrc", ".zshrc" etc.
-```
-export GTYPIST_PATH=/Path/to/script/file
+## Optional Install Path
+
+GNU Typist can load lesson files from directories listed in `GTYPIST_PATH`. Add this repository path to your shell profile if you want to run the lessons from anywhere:
+
+```sh
+export GTYPIST_PATH=/path/to/gtypist-lesson
 ```
 
-## Requirement
-This script requires "GNU Typist".
-Please install with package etc.
+Then run:
 
-**Debian/Ubuntu**
+```sh
+gtypist keyquest.typ
 ```
-$ sudo apt install gtypist
-```
-**OSX**
-```
-$ brew install gtypist
-```
+
+## KeyQuest Curriculum
+
+`keyquest.typ` ports the first four implemented KeyQuest arcs into gtypist:
+
+- Days 1-7, Novice Hall: home position, finger ownership, home-row accuracy, and the Gatekeeper Trial.
+- Days 8-14, Meadow Road: top-row reach and the Waystone Trial.
+- Days 15-21, River Gate: bottom-row movement, bridge keys, comma, period, and the Ferryman Trial.
+- Days 22-28, Lantern Keep: number-row control, simple codes, map labels, and the Beacon Trial.
+
+The original KeyQuest game presents these lessons through RPG progression, story scenes, scoring, and rewards. GNU Typist is a simpler terminal trainer, so this port keeps the typing substance and reshapes the experience into menus, concise training notes, and drill lines.
+
+## Recommended Practice
+
+Use one day per session. Repeat a day when accuracy feels unstable, especially during the first week. The early lessons are intentionally short and repetitive because KeyQuest prioritizes home position, finger responsibility, and calm accuracy before speed.
+
+For a deeper curriculum map and maintenance notes, see [`docs/keyquest-curriculum.md`](docs/keyquest-curriculum.md).
 
 ## Author
-This script was written by Hideyuki Mori of Ayane International Inc.
+
+The original `xion.typ` script was written by Hideyuki Mori of Ayane International Inc.
+
+The `keyquest.typ` script adapts KeyQuest lesson content for GNU Typist.

--- a/docs/keyquest-curriculum.md
+++ b/docs/keyquest-curriculum.md
@@ -1,0 +1,96 @@
+# KeyQuest Curriculum for GNU Typist
+
+This manual explains how `keyquest.typ` adapts the first 28 implemented KeyQuest lessons to GNU Typist.
+
+KeyQuest is designed as a terminal typing adventure. Its source lessons are JSON files with metadata, target keys, skill tracks, finger hints, and English prompts. GNU Typist uses a compact `.typ` script language, so this port turns the same curriculum into menus, banners, text notes, key introductions, and drill lines.
+
+## How to Run
+
+```sh
+gtypist keyquest.typ
+```
+
+Choose an arc from the main menu, then choose a day. The lesson returns to its arc menu when complete.
+
+## Adaptation Rules
+
+- Each KeyQuest JSON lesson became one GNU Typist lesson block.
+- KeyQuest prompt text remains English.
+- Very short prompts are repeated on a drill line so gtypist practice is not too brief.
+- `targetKeys` metadata becomes the gtypist `I:` key group for each drill.
+- RPG systems such as XP, HP, MP, inventory, story gates, and achievements are not simulated in gtypist.
+- Story flavor is kept as concise training framing so the screen stays calm while typing.
+
+## Practice Philosophy
+
+The first KeyQuest month is accuracy-first. Type slowly enough that each finger returns to home position after every reach. Do not chase speed during the early lessons. Repeat a day when the hand shape feels unstable.
+
+## Arc Overview
+
+### Novice Hall (Days 1-7)
+
+The first week is intentionally stubborn: small patterns, mirrored pairs, home-row ownership, and accuracy before speed.
+
+- Day 01: Novice Hall: Home Position - Learn the calm home stance and anchor both index fingers on f and j. Focus: home position, left index, right index, home row accuracy.
+- Day 02: Novice Hall: Left And Right Balance - Balance left and right hands without rushing the home row. Focus: left hand balance, right hand balance, home row rhythm.
+- Day 03: Novice Hall: Finger Responsibility - Reinforce which finger owns each home-row key. Focus: finger responsibility, home row ownership, calm correction.
+- Day 04: Novice Hall: Rhythm Hall - Build a steady cadence with familiar home-row combinations. Focus: home row rhythm, spacing, steady cadence.
+- Day 05: Novice Hall: First Words - Connect home-row drills to tiny readable English word groups. Focus: short words, home row posture, word accuracy.
+- Day 06: Novice Hall: Repair The Stance - Repair weak-finger habits with slow, accurate review. Focus: weak finger repair, slow perfect typing, home row recovery.
+- Day 07: Novice Hall: Gatekeeper Trial - Prove the first-week home-row basics in a gatekeeper trial. Focus: home row trial, accuracy check, calm recovery.
+
+### Meadow Road (Days 8-14)
+
+The second week expands into nearby top-row keys while repeatedly returning the hands to home position.
+
+- Day 08: Meadow Road: First Steps Beyond Home - Step beyond home row with r, u, e, and i while returning home. Focus: vertical movement, nearby top row keys, return to home.
+- Day 09: Meadow Road: Ring Finger Reach - Practice ring-finger top-row reach with w and o. Focus: ring finger reach, w and o, return to home.
+- Day 10: Meadow Road: Index Reach - Practice index-finger reach with t and y in short patterns. Focus: index reach, t and y, controlled stretch.
+- Day 11: Meadow Road: Outer Watch - Add the outer pinky top-row keys q and p carefully. Focus: outer reach, q and p, return to home.
+- Day 12: Meadow Road: Top Row Trail - Travel across the top row in short lateral patterns. Focus: top row travel, lateral control, steady return.
+- Day 13: Meadow Road: First Flow - Type short English word flow using home row and top row. Focus: short word flow, top row words, calm rhythm.
+- Day 14: Meadow Road: Waystone Trial - Check top-row control in a deliberate Waystone Trial. Focus: weekly checkpoint, top row control, accuracy under pressure.
+
+### River Gate (Days 15-21)
+
+The third week adds bottom-row movement, bridge letters, and the first punctuation checkpoint.
+
+- Day 15: River Gate: Lower Step - Introduce lower-step movement with c and m. Focus: bottom row introduction, c and m, return to home.
+- Day 16: River Gate: Valley Reach - Practice valley reach with v and n while keeping hands quiet. Focus: bottom row reach, v and n, index control.
+- Day 17: River Gate: Bridge Keys - Bridge rows around b, g, and h without drifting from home. Focus: index bridge, b and g h, center control.
+- Day 18: River Gate: Comma And Period - Add comma and period practice with the right hand. Focus: comma, period, right-hand punctuation.
+- Day 19: River Gate: Bottom Row Words - Use bottom-row words inside short readable phrases. Focus: bottom row words, mixed rows, accuracy.
+- Day 20: River Gate: Current Review - Review mixed rows and punctuation with calm recovery. Focus: mixed-row review, punctuation review, steady cadence.
+- Day 21: River Gate: Ferryman Trial - Cross the Ferryman Trial for bottom-row and punctuation control. Focus: weekly checkpoint, bottom row control, punctuation under pressure.
+
+### Lantern Keep (Days 22-28)
+
+The fourth week introduces digits in small groups before mixing them into readable English prompts.
+
+- Day 22: Lantern Keep: Left Number Row - Introduce the left number row with 1, 2, 3, and 4. Focus: left number row, upper reach, accuracy.
+- Day 23: Lantern Keep: Right Number Row - Introduce the right number row with 7, 8, 9, and 0. Focus: right number row, upper reach, rhythm.
+- Day 24: Lantern Keep: Center Span - Practice the center number span with 4, 5, 6, and 7. Focus: center number row, index reach, steady return.
+- Day 25: Lantern Keep: Counts And Codes - Type short counts and codes without losing home-position shape. Focus: number words, short codes, accuracy under context.
+- Day 26: Lantern Keep: Map Marks - Practice map labels and room numbers as practical digit prompts. Focus: map labels, mixed rows, number accuracy.
+- Day 27: Lantern Keep: Mixed Signals - Mix number-row instructions while keeping rhythm stable. Focus: mixed number row, short instructions, steady cadence.
+- Day 28: Lantern Keep: Beacon Trial - Clear the Beacon Trial for number-row control. Focus: weekly checkpoint, number row control, mixed instruction accuracy.
+
+## File Map
+
+- `keyquest.typ`: GNU Typist script for the KeyQuest 28-day journey.
+- `xion.typ`: original weak-finger etude script, kept unchanged.
+- `README.md`: installation and quick usage guide.
+- `docs/keyquest-curriculum.md`: this curriculum manual.
+
+## Maintaining Future Lessons
+
+When new KeyQuest lessons are added, keep the gtypist version small and explicit:
+
+1. Add the day to the appropriate arc menu or create a new arc menu.
+2. Add one `*:DAY_NN` label for the lesson.
+3. Use `B:` for the day title and `T:` lines for the practice goal.
+4. Use `I:` to introduce target keys before each drill.
+5. Use `D:` and continuation lines starting with ` :` for the actual typing text.
+6. End the lesson with `G:` back to the arc menu.
+
+Keep drill lines readable in a normal terminal. If a KeyQuest prompt is extremely short, repeat it several times. If it is long, split it into multiple gtypist continuation lines.

--- a/keyquest.typ
+++ b/keyquest.typ
@@ -1,0 +1,542 @@
+*:MENU
+M: "KeyQuest Typing Journey"
+ :NOVICE_HALL  "Novice Hall"
+ :MEADOW_ROAD  "Meadow Road"
+ :RIVER_GATE  "River Gate"
+ :LANTERN_KEEP  "Lantern Keep"
+ :ABOUT  "About this script"
+ :EXIT  "Exit"
+
+*:NOVICE_HALL
+M: "Novice Hall"
+ :DAY_01  "Day 01: Home Position"
+ :DAY_02  "Day 02: Left And Right Balance"
+ :DAY_03  "Day 03: Finger Responsibility"
+ :DAY_04  "Day 04: Rhythm Hall"
+ :DAY_05  "Day 05: First Words"
+ :DAY_06  "Day 06: Repair The Stance"
+ :DAY_07  "Day 07: Gatekeeper Trial"
+ :MENU  "Back to arc menu"
+
+*:MEADOW_ROAD
+M: "Meadow Road"
+ :DAY_08  "Day 08: First Steps Beyond Home"
+ :DAY_09  "Day 09: Ring Finger Reach"
+ :DAY_10  "Day 10: Index Reach"
+ :DAY_11  "Day 11: Outer Watch"
+ :DAY_12  "Day 12: Top Row Trail"
+ :DAY_13  "Day 13: First Flow"
+ :DAY_14  "Day 14: Waystone Trial"
+ :MENU  "Back to arc menu"
+
+*:RIVER_GATE
+M: "River Gate"
+ :DAY_15  "Day 15: Lower Step"
+ :DAY_16  "Day 16: Valley Reach"
+ :DAY_17  "Day 17: Bridge Keys"
+ :DAY_18  "Day 18: Comma And Period"
+ :DAY_19  "Day 19: Bottom Row Words"
+ :DAY_20  "Day 20: Current Review"
+ :DAY_21  "Day 21: Ferryman Trial"
+ :MENU  "Back to arc menu"
+
+*:LANTERN_KEEP
+M: "Lantern Keep"
+ :DAY_22  "Day 22: Left Number Row"
+ :DAY_23  "Day 23: Right Number Row"
+ :DAY_24  "Day 24: Center Span"
+ :DAY_25  "Day 25: Counts And Codes"
+ :DAY_26  "Day 26: Map Marks"
+ :DAY_27  "Day 27: Mixed Signals"
+ :DAY_28  "Day 28: Beacon Trial"
+ :MENU  "Back to arc menu"
+
+*:DAY_01
+B:KeyQuest - Day 01 - Novice Hall: Home Position
+T:Learn the calm home stance and anchor both index fingers on f and j.
+ :Arc: Novice Hall. Home position, finger responsibility, and calm
+ :home-row accuracy.
+ :Focus: home position, left index, right index, home row accuracy.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)f&j - home-position-1
+D:f j f j f j f j f j f j f j f j
+I:(2)f&j - home-position-2
+D:ff jj ff jj ff jj ff jj ff jj ff jj ff jj ff jj
+I:(3)f&j - home-position-3
+D:fj jf fj jf fj jf fj jf fj jf fj jf fj jf fj jf
+I:(4)a&s&d&f&j&k&l&; - home-position-4
+D:asdf jkl; asdf jkl; asdf jkl; asdf jkl; asdf jkl; asdf jkl;
+
+G:NOVICE_HALL
+
+*:DAY_02
+B:KeyQuest - Day 02 - Novice Hall: Left And Right Balance
+T:Balance left and right hands without rushing the home row.
+ :Arc: Novice Hall. Home position, finger responsibility, and calm
+ :home-row accuracy.
+ :Focus: left hand balance, right hand balance, home row rhythm.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)a&s&d&f&j&k&l&; - left-right-balance-1
+D:asdf jkl; asdf jkl; asdf jkl; asdf jkl; asdf jkl; asdf jkl;
+I:(2)a&s&d&f&j&k&l&; - left-right-balance-2
+D:asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj
+I:(3)a&f&s&j&d&k&l - left-right-balance-3
+D:af sj dk fl af sj dk fl af sj dk fl af sj dk fl af sj dk fl
+I:(4)a&s&d&f&j&k&l - left-right-balance-4
+D:sad lad ask fall sad lad ask fall sad lad ask fall sad lad ask fall
+
+G:NOVICE_HALL
+
+*:DAY_03
+B:KeyQuest - Day 03 - Novice Hall: Finger Responsibility
+T:Reinforce which finger owns each home-row key.
+ :Arc: Novice Hall. Home position, finger responsibility, and calm
+ :home-row accuracy.
+ :Focus: finger responsibility, home row ownership, calm correction.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)a&s&d&f&j&k&l&; - finger-responsibility-1
+D:aa ss dd ff jj kk ll ;; aa ss dd ff jj kk ll ;;
+I:(2)a&s&d&f&j&k&l&; - finger-responsibility-2
+D:as df jk l; as df jk l; as df jk l; as df jk l; as df jk l;
+I:(3)a&;&s&l&d&k&f&j - finger-responsibility-3
+D:a; sl dk fj a; sl dk fj a; sl dk fj a; sl dk fj a; sl dk fj
+I:(4)a&s&d&f&j&k&l - finger-responsibility-4
+D:ask sad fall flask ask sad fall flask ask sad fall flask
+
+G:NOVICE_HALL
+
+*:DAY_04
+B:KeyQuest - Day 04 - Novice Hall: Rhythm Hall
+T:Build a steady cadence with familiar home-row combinations.
+ :Arc: Novice Hall. Home position, finger responsibility, and calm
+ :home-row accuracy.
+ :Focus: home row rhythm, spacing, steady cadence.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)a&s&d&f&j&k&l&; - rhythm-hall-1
+D:asdf asdf jkl; jkl; asdf asdf jkl; jkl; asdf asdf jkl; jkl;
+I:(2)f&d&s&a&;&l&k&j - rhythm-hall-2
+D:fdsa fdsa ;lkj ;lkj fdsa fdsa ;lkj ;lkj fdsa fdsa ;lkj ;lkj
+I:(3)a&s&d&f&j&k&l&; - rhythm-hall-3
+D:asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj
+I:(4)a&s&d&f&j&k&l - rhythm-hall-4
+D:ask fall sad flask ask fall sad flask ask fall sad flask
+
+G:NOVICE_HALL
+
+*:DAY_05
+B:KeyQuest - Day 05 - Novice Hall: First Words
+T:Connect home-row drills to tiny readable English word groups.
+ :Arc: Novice Hall. Home position, finger responsibility, and calm
+ :home-row accuracy.
+ :Focus: short words, home row posture, word accuracy.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)a&s&d&l&k - first-words-1
+D:ask sad lad ask sad lad ask sad lad ask sad lad ask sad lad
+I:(2)f&a&l&s&k - first-words-2
+D:fall flask fall flask fall flask fall flask fall flask fall flask
+I:(3)d&a&f&s&l - first-words-3
+D:dad fad salad dad fad salad dad fad salad dad fad salad
+I:(4)a&s&k&l&d&f - first-words-4
+D:ask lad fall flask ask lad fall flask ask lad fall flask
+
+G:NOVICE_HALL
+
+*:DAY_06
+B:KeyQuest - Day 06 - Novice Hall: Repair The Stance
+T:Repair weak-finger habits with slow, accurate review.
+ :Arc: Novice Hall. Home position, finger responsibility, and calm
+ :home-row accuracy.
+ :Focus: weak finger repair, slow perfect typing, home row recovery.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)a&;&s&l - repair-stance-1
+D:aa ;; ss ll aa ;; ss ll aa ;; ss ll aa ;; ss ll aa ;; ss ll
+I:(2)a&;&s&l - repair-stance-2
+D:a; s; al sl a; s; al sl a; s; al sl a; s; al sl a; s; al sl
+I:(3)s&a&d&l&f - repair-stance-3
+D:sad lass fall sad lass fall sad lass fall sad lass fall
+I:(4)a&s&k&l&f&d - repair-stance-4
+D:ask lass fall salad ask lass fall salad ask lass fall salad
+
+G:NOVICE_HALL
+
+*:DAY_07
+B:KeyQuest - Day 07 - Novice Hall: Gatekeeper Trial
+T:Prove the first-week home-row basics in a gatekeeper trial.
+ :Arc: Novice Hall. Home position, finger responsibility, and calm
+ :home-row accuracy.
+ :Focus: home row trial, accuracy check, calm recovery.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)f&j&a&s&d&k&l&; - gatekeeper-trial-1
+D:f j as df jk l; f j as df jk l; f j as df jk l; f j as df jk l;
+I:(2)a&s&d&f&j&k&l&; - gatekeeper-trial-2
+D:asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj
+I:(3)a&s&k&d&l&f - gatekeeper-trial-3
+D:ask sad lad fall ask sad lad fall ask sad lad fall ask sad lad fall
+I:(4)a&s&k&l&f&d - gatekeeper-trial-boss
+D:ask lass fall salad flask ask lass fall salad flask
+
+G:NOVICE_HALL
+
+*:DAY_08
+B:KeyQuest - Day 08 - Meadow Road: First Steps Beyond Home
+T:Step beyond home row with r, u, e, and i while returning home.
+ :Arc: Meadow Road. Top-row reach while preserving the same home-position
+ :discipline.
+ :Focus: vertical movement, nearby top row keys, return to home.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)f&r&j&u - meadow-road-1
+D:fr ju fr ju fr ju fr ju fr ju fr ju fr ju fr ju fr ju fr ju
+I:(2)d&e&k&i - meadow-road-2
+D:de ki de ki de ki de ki de ki de ki de ki de ki de ki de ki
+I:(3)r&e&d&k&i - meadow-road-3
+D:red kid ride red kid ride red kid ride red kid ride red kid ride
+I:(4)r&u&d&e&i - meadow-road-4
+D:rude deer ride rude deer ride rude deer ride rude deer ride
+
+G:MEADOW_ROAD
+
+*:DAY_09
+B:KeyQuest - Day 09 - Meadow Road: Ring Finger Reach
+T:Practice ring-finger top-row reach with w and o.
+ :Arc: Meadow Road. Top-row reach while preserving the same home-position
+ :discipline.
+ :Focus: ring finger reach, w and o, return to home.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)s&w&l&o - meadow-road-ring-1
+D:sw lo sw lo sw lo sw lo sw lo sw lo sw lo sw lo sw lo sw lo
+I:(2)w&e&o&l&d - meadow-road-ring-2
+D:we old we old we old we old we old we old we old we old
+I:(3)s&l&o&w - meadow-road-ring-3
+D:slow low owl slow low owl slow low owl slow low owl slow low owl
+I:(4)o&l&d&w&s - meadow-road-ring-4
+D:old owl slow old owl slow old owl slow old owl slow old owl slow
+
+G:MEADOW_ROAD
+
+*:DAY_10
+B:KeyQuest - Day 10 - Meadow Road: Index Reach
+T:Practice index-finger reach with t and y in short patterns.
+ :Arc: Meadow Road. Top-row reach while preserving the same home-position
+ :discipline.
+ :Focus: index reach, t and y, controlled stretch.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)f&t&j&y - meadow-road-index-1
+D:ft jy ft jy ft jy ft jy ft jy ft jy ft jy ft jy ft jy ft jy
+I:(2)t&r&y&e - meadow-road-index-2
+D:try yet try yet try yet try yet try yet try yet try yet try yet
+I:(3)d&r&y&t&a - meadow-road-index-3
+D:dry try yard dry try yard dry try yard dry try yard dry try yard
+I:(4)s&t&a&y&r&e&d - meadow-road-index-4
+D:stay ready steady stay ready steady stay ready steady
+
+G:MEADOW_ROAD
+
+*:DAY_11
+B:KeyQuest - Day 11 - Meadow Road: Outer Watch
+T:Add the outer pinky top-row keys q and p carefully.
+ :Arc: Meadow Road. Top-row reach while preserving the same home-position
+ :discipline.
+ :Focus: outer reach, q and p, return to home.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)a&q&;&p - meadow-road-outer-1
+D:aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p
+I:(2)q&u&i&c&k&e&t - meadow-road-outer-2
+D:quick quiet quick quiet quick quiet quick quiet quick quiet
+I:(3)p&o&i&e&u - meadow-road-outer-3
+D:pop pipe pup pop pipe pup pop pipe pup pop pipe pup pop pipe pup
+I:(4)q&u&i&p&c&k&o - meadow-road-outer-4
+D:quip quick pop quip quick pop quip quick pop quip quick pop
+
+G:MEADOW_ROAD
+
+*:DAY_12
+B:KeyQuest - Day 12 - Meadow Road: Top Row Trail
+T:Travel across the top row in short lateral patterns.
+ :Arc: Meadow Road. Top-row reach while preserving the same home-position
+ :discipline.
+ :Focus: top row travel, lateral control, steady return.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)q&w&e&r&u&i&o&p - meadow-road-trail-1
+D:qwer uiop qwer uiop qwer uiop qwer uiop qwer uiop qwer uiop
+I:(2)t&r&e&w&p&o&i - meadow-road-trail-2
+D:trew poi poi trew trew poi poi trew trew poi poi trew
+I:(3)w&e&q&u&i&t&p&o - meadow-road-trail-3
+D:we quit we pop we quit we pop we quit we pop we quit we pop
+I:(4)t&y&p&e&u&r&q&i - meadow-road-trail-4
+D:type pure quiet type pure quiet type pure quiet type pure quiet
+
+G:MEADOW_ROAD
+
+*:DAY_13
+B:KeyQuest - Day 13 - Meadow Road: First Flow
+T:Type short English word flow using home row and top row.
+ :Arc: Meadow Road. Top-row reach while preserving the same home-position
+ :discipline.
+ :Focus: short word flow, top row words, calm rhythm.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)q&u&i&e&t&r&d - meadow-road-flow-1
+D:quiet rider quiet rider quiet rider quiet rider quiet rider
+I:(2)t&y&p&e&o&u&r&s - meadow-road-flow-2
+D:type your story type your story type your story type your story
+I:(3)w&e&t&r&y&q&u&i&o&k - meadow-road-flow-3
+D:we try quiet work we try quiet work we try quiet work
+I:(4)s&t&e&a&d&y&h&n&p&r&u - meadow-road-flow-4
+D:steady hands type true steady hands type true
+
+G:MEADOW_ROAD
+
+*:DAY_14
+B:KeyQuest - Day 14 - Meadow Road: Waystone Trial
+T:Check top-row control in a deliberate Waystone Trial.
+ :Arc: Meadow Road. Top-row reach while preserving the same home-position
+ :discipline.
+ :Focus: weekly checkpoint, top row control, accuracy under pressure.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)q&w&e&r&u&i&o&p&a&s&d&f - meadow-road-trial-1
+D:qwer uiop asdf jkl; qwer uiop asdf jkl; qwer uiop asdf jkl;
+I:(2)q&u&i&e&t&y&p&r&w&o&k - meadow-road-trial-2
+D:quiet type pure work quiet type pure work quiet type pure work
+I:(3)s&t&e&a&d&y&q&u&i&r - meadow-road-trial-3
+D:steady quiet rider steady quiet rider steady quiet rider
+I:(4)y&o&u&r&q&i&e&t&s&a&d&h - meadow-road-trial-waystone
+D:your quiet steady hands type true your quiet steady hands type true
+
+G:MEADOW_ROAD
+
+*:DAY_15
+B:KeyQuest - Day 15 - River Gate: Lower Step
+T:Introduce lower-step movement with c and m.
+ :Arc: River Gate. Bottom-row movement, bridge keys, and punctuation
+ :control.
+ :Focus: bottom row introduction, c and m, return to home.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)d&c&k&m - river-gate-lower-1
+D:dc km dc km dc km dc km dc km dc km dc km dc km dc km dc km
+I:(2)c&o&m&e&a&l - river-gate-lower-2
+D:come calm come calm come calm come calm come calm come calm
+I:(3)m&a&k&e&c&l&o&v&s - river-gate-lower-3
+D:make calm moves make calm moves make calm moves make calm moves
+
+G:RIVER_GATE
+
+*:DAY_16
+B:KeyQuest - Day 16 - River Gate: Valley Reach
+T:Practice valley reach with v and n while keeping hands quiet.
+ :Arc: River Gate. Bottom-row movement, bridge keys, and punctuation
+ :control.
+ :Focus: bottom row reach, v and n, index control.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)f&v&j&n - river-gate-valley-1
+D:fv jn fv jn fv jn fv jn fv jn fv jn fv jn fv jn fv jn fv jn
+I:(2)e&v&n&i - river-gate-valley-2
+D:even nine even nine even nine even nine even nine even nine
+I:(3)m&o&v&e&n&r&a&i&s&h - river-gate-valley-3
+D:move never vanish move never vanish move never vanish
+
+G:RIVER_GATE
+
+*:DAY_17
+B:KeyQuest - Day 17 - River Gate: Bridge Keys
+T:Bridge rows around b, g, and h without drifting from home.
+ :Arc: River Gate. Bottom-row movement, bridge keys, and punctuation
+ :control.
+ :Focus: index bridge, b and g h, center control.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)f&g&j&h&b&n - river-gate-bridge-1
+D:fg jh fb jn fg jh fb jn fg jh fb jn fg jh fb jn fg jh fb jn
+I:(2)b&r&i&n&g&h&t - river-gate-bridge-2
+D:bring bright bring bright bring bright bring bright
+I:(3)b&e&g&i&n&t&h&r&d - river-gate-bridge-3
+D:begin the bridge begin the bridge begin the bridge begin the bridge
+
+G:RIVER_GATE
+
+*:DAY_18
+B:KeyQuest - Day 18 - River Gate: Comma And Period
+T:Add comma and period practice with the right hand.
+ :Arc: River Gate. Bottom-row movement, bridge keys, and punctuation
+ :control.
+ :Focus: comma, period, right-hand punctuation.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)k&,&l&. - river-gate-punct-1
+D:k, l. k, l. k, l. k, l. k, l. k, l. k, l. k, l. k, l. k, l.
+I:(2)c&a&l&m&,&s&t&e&d&y&. - river-gate-punct-2
+D:calm, steady. calm, steady. calm, steady. calm, steady.
+I:(3)m&o&v&e&,&r&s&t&. - river-gate-punct-3
+D:move, rest. move, rest. move, rest. move, rest.
+
+G:RIVER_GATE
+
+*:DAY_19
+B:KeyQuest - Day 19 - River Gate: Bottom Row Words
+T:Use bottom-row words inside short readable phrases.
+ :Arc: River Gate. Bottom-row movement, bridge keys, and punctuation
+ :control.
+ :Focus: bottom row words, mixed rows, accuracy.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)b&r&a&v&e&m&o&c&l - river-gate-words-1
+D:brave move calm brave move calm brave move calm brave move calm
+I:(2)n&e&v&r&b&i&g&p&a&c - river-gate-words-2
+D:never bring panic never bring panic never bring panic
+I:(3)s&t&e&a&d&y&r&i&v&,&b&h - river-gate-words-3
+D:steady river, brave hands. steady river, brave hands.
+
+G:RIVER_GATE
+
+*:DAY_20
+B:KeyQuest - Day 20 - River Gate: Current Review
+T:Review mixed rows and punctuation with calm recovery.
+ :Arc: River Gate. Bottom-row movement, bridge keys, and punctuation
+ :control.
+ :Focus: mixed-row review, punctuation review, steady cadence.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)q&w&e&r&a&s&d&f&z&x&c&v - river-gate-review-1
+D:qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv
+I:(2)u&i&o&p&j&k&l&;&n&m&,&. - river-gate-review-2
+D:uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,.
+I:(3)b&r&i&n&g&c&a&l&m&,&o&v - river-gate-review-3
+D:bring calm, move steady. bring calm, move steady.
+
+G:RIVER_GATE
+
+*:DAY_21
+B:KeyQuest - Day 21 - River Gate: Ferryman Trial
+T:Cross the Ferryman Trial for bottom-row and punctuation control.
+ :Arc: River Gate. Bottom-row movement, bridge keys, and punctuation
+ :control.
+ :Focus: weekly checkpoint, bottom row control, punctuation under
+ :pressure.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)a&s&d&f&q&w&e&r&z&x&c&v - river-gate-trial-1
+D:asdf qwer zxcv asdf qwer zxcv asdf qwer zxcv asdf qwer zxcv
+I:(2)j&k&l&;&u&i&o&p&n&m&,&. - river-gate-trial-2
+D:jkl; uiop nm,. jkl; uiop nm,. jkl; uiop nm,. jkl; uiop nm,.
+I:(3)n&e&v&r&p&a&i&c&,&m&o&s - river-gate-trial-3
+D:never panic, move steady. never panic, move steady.
+I:(4)b&r&a&v&e&h&n&d&s&c&o&t - river-gate-trial-ferryman
+D:brave hands cross the quiet river. brave hands cross the quiet river.
+
+G:RIVER_GATE
+
+*:DAY_22
+B:KeyQuest - Day 22 - Lantern Keep: Left Number Row
+T:Introduce the left number row with 1, 2, 3, and 4.
+ :Arc: Lantern Keep. Number-row reach and practical mixed digit prompts.
+ :Focus: left number row, upper reach, accuracy.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)1&2&3&4 - lantern-left-number-1
+D:1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4
+I:(2)1&2&3&4 - lantern-left-number-2
+D:11 22 33 44 11 22 33 44 11 22 33 44 11 22 33 44 11 22 33 44
+I:(3)r&o&m&1&2&g&a&t&e&3&4 - lantern-left-number-3
+D:room 12 gate 34 room 12 gate 34 room 12 gate 34 room 12 gate 34
+
+G:LANTERN_KEEP
+
+*:DAY_23
+B:KeyQuest - Day 23 - Lantern Keep: Right Number Row
+T:Introduce the right number row with 7, 8, 9, and 0.
+ :Arc: Lantern Keep. Number-row reach and practical mixed digit prompts.
+ :Focus: right number row, upper reach, rhythm.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)7&8&9&0 - lantern-right-number-1
+D:7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0
+I:(2)7&8&9&0 - lantern-right-number-2
+D:77 88 99 00 77 88 99 00 77 88 99 00 77 88 99 00 77 88 99 00
+I:(3)t&o&w&e&r&7&8&p&a&h&9&0 - lantern-right-number-3
+D:tower 78 path 90 tower 78 path 90 tower 78 path 90 tower 78 path 90
+
+G:LANTERN_KEEP
+
+*:DAY_24
+B:KeyQuest - Day 24 - Lantern Keep: Center Span
+T:Practice the center number span with 4, 5, 6, and 7.
+ :Arc: Lantern Keep. Number-row reach and practical mixed digit prompts.
+ :Focus: center number row, index reach, steady return.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)4&5&6&7 - lantern-center-span-1
+D:4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7
+I:(2)4&5&6&7 - lantern-center-span-2
+D:45 56 67 76 65 54 45 56 67 76 65 54 45 56 67 76 65 54
+I:(3)l&e&v&4&5&b&r&i&d&g&6&7 - lantern-center-span-3
+D:level 45 bridge 67 level 45 bridge 67 level 45 bridge 67
+
+G:LANTERN_KEEP
+
+*:DAY_25
+B:KeyQuest - Day 25 - Lantern Keep: Counts And Codes
+T:Type short counts and codes without losing home-position shape.
+ :Arc: Lantern Keep. Number-row reach and practical mixed digit prompts.
+ :Focus: number words, short codes, accuracy under context.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)t&a&k&e&2&y&s&3&m&p - lantern-counts-1
+D:take 2 keys and 3 maps take 2 keys and 3 maps
+I:(2)m&a&r&k&4&o&s&b&e&f&5 - lantern-counts-2
+D:mark 4 rooms before 5 mark 4 rooms before 5 mark 4 rooms before 5
+I:(3)c&o&d&e&1&2&0&p&n&s&g&a - lantern-counts-3
+D:code 120 opens gate 34 code 120 opens gate 34
+
+G:LANTERN_KEEP
+
+*:DAY_26
+B:KeyQuest - Day 26 - Lantern Keep: Map Marks
+T:Practice map labels and room numbers as practical digit prompts.
+ :Arc: Lantern Keep. Number-row reach and practical mixed digit prompts.
+ :Focus: map labels, mixed rows, number accuracy.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)m&a&p&1&r&o&2&h&l&3 - lantern-map-marks-1
+D:map 1 room 2 hall 3 map 1 room 2 hall 3 map 1 room 2 hall 3
+I:(2)t&u&r&n&6&h&e&o&p&7 - lantern-map-marks-2
+D:turn 6 then open 7 turn 6 then open 7 turn 6 then open 7
+I:(3)l&a&m&p&8&s&h&o&w&d&r&9 - lantern-map-marks-3
+D:lamp 8 shows door 9 lamp 8 shows door 9 lamp 8 shows door 9
+
+G:LANTERN_KEEP
+
+*:DAY_27
+B:KeyQuest - Day 27 - Lantern Keep: Mixed Signals
+T:Mix number-row instructions while keeping rhythm stable.
+ :Arc: Lantern Keep. Number-row reach and practical mixed digit prompts.
+ :Focus: mixed number row, short instructions, steady cadence.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)l&e&v&2&m&a&p&4&g&t&6 - lantern-mixed-signals-1
+D:level 2 map 4 gate 6 level 2 map 4 gate 6 level 2 map 4 gate 6
+I:(2)p&a&t&h&8&r&o&m&1&0 - lantern-mixed-signals-2
+D:path 8 room 10 path 8 room 10 path 8 room 10 path 8 room 10
+I:(3)s&t&e&a&d&y&h&n&r&i&g&l - lantern-mixed-signals-3
+D:steady hands read signal 27 steady hands read signal 27
+
+G:LANTERN_KEEP
+
+*:DAY_28
+B:KeyQuest - Day 28 - Lantern Keep: Beacon Trial
+T:Clear the Beacon Trial for number-row control.
+ :Arc: Lantern Keep. Number-row reach and practical mixed digit prompts.
+ :Focus: weekly checkpoint, number row control, mixed instruction
+ :accuracy.
+ :Type slowly enough that every finger can return home after each reach.
+I:(1)1&2&3&4&5&6&7&8&9&0 - lantern-trial-1
+D:1234 567 890 1234 567 890 1234 567 890 1234 567 890 1234 567 890
+I:(2)g&a&t&e&1&2&r&o&m&3&4&p - lantern-trial-2
+D:gate 12 room 34 path 56 gate 12 room 34 path 56
+I:(3)m&a&r&k&7&8&t&h&e&n&o&p - lantern-trial-3
+D:mark 78 then open 90 mark 78 then open 90 mark 78 then open 90
+I:(4)t&h&e&b&a&c&o&n&p&s&l&v - lantern-trial-beacon
+D:the beacon opens at level 28. the beacon opens at level 28.
+
+G:LANTERN_KEEP
+
+*:ABOUT
+B:About KeyQuest Typing Journey
+T:This GNU Typist script adapts the first 28 implemented KeyQuest lessons.
+ :The original game uses JSON lessons, RPG progression, rewards, and story
+ :scenes. This port keeps the English typing prompts and turns the journey
+ :into simple terminal drills for gtypist.
+ :Use one day at a time, repeat lessons when accuracy drops, and value calm
+ :finger placement over speed.
+G:MENU
+
+*:EXIT
+B:Thank you for training with KeyQuest.
+T:Practice a little every day. Accuracy opens the next gate.
+X:


### PR DESCRIPTION
## Summary
- Add `keyquest.typ`, a GNU Typist adaptation of the first 28 implemented KeyQuest lessons.
- Organize the curriculum by the four implemented arcs: Novice Hall, Meadow Road, River Gate, and Lantern Keep.
- Expand README usage guidance and add a dedicated curriculum/manual document.

## Test plan
- Statically checked `keyquest.typ` label, menu, and `G:` references.
- Confirmed generated drill lines stay within terminal-friendly width.
- Smoke-checked `gtypist -q -S -l ABOUT keyquest.typ` startup with a timeout because gtypist is interactive.

Closes #2.

Made with [Cursor](https://cursor.com)