### PR TITLE
Expand KeyQuest gtypist journey to 90 days

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Touch typing practice scripts for [GNU Typist](https://www.gnu.org/software/gtyp
 This repository contains two terminal lesson scripts:
 
 - `xion.typ`: the original weak-finger etude collection.
-- `keyquest.typ`: a GNU Typist adaptation of the first 28 implemented KeyQuest lessons.
+- `keyquest.typ`: a 90-day GNU Typist typing journey adapted from KeyQuest.
 
 ## Requirements
 
@@ -53,18 +53,17 @@ gtypist keyquest.typ
 
 ## KeyQuest Curriculum
 
-`keyquest.typ` ports the first four implemented KeyQuest arcs into gtypist:
+`keyquest.typ` provides a full 90-day gtypist version of the KeyQuest journey:
 
-- Days 1-7, Novice Hall: home position, finger ownership, home-row accuracy, and the Gatekeeper Trial.
-- Days 8-14, Meadow Road: top-row reach and the Waystone Trial.
-- Days 15-21, River Gate: bottom-row movement, bridge keys, comma, period, and the Ferryman Trial.
-- Days 22-28, Lantern Keep: number-row control, simple codes, map labels, and the Beacon Trial.
+- Days 1-28 preserve the implemented KeyQuest lesson prompts and reshape them for gtypist drills.
+- Days 29-90 are gtypist-native extensions based on KeyQuest's official quest map themes.
+- The journey covers 12 weekly arcs plus a 6-day finale, from home position through full-keyboard mastery.
 
-The original KeyQuest game presents these lessons through RPG progression, story scenes, scoring, and rewards. GNU Typist is a simpler terminal trainer, so this port keeps the typing substance and reshapes the experience into menus, concise training notes, and drill lines.
+The original KeyQuest game presents lessons through RPG progression, story scenes, scoring, and rewards. GNU Typist is a simpler terminal trainer, so this port keeps the typing substance and reshapes the experience into menus, concise training notes, and drill lines.
 
 ## Recommended Practice
 
-Use one day per session. Repeat a day when accuracy feels unstable, especially during the first week. The early lessons are intentionally short and repetitive because KeyQuest prioritizes home position, finger responsibility, and calm accuracy before speed.
+Use one day per session. Repeat a day when accuracy feels unstable. The first month is intentionally repetitive because KeyQuest prioritizes home position, finger responsibility, and calm accuracy before speed. Later arcs add Shift, symbols, code-like patterns, longer phrases, recovery, and final integrated review.
 
 For a deeper curriculum map and maintenance notes, see [`docs/keyquest-curriculum.md`](docs/keyquest-curriculum.md).
 
@@ -72,4 +71,4 @@ For a deeper curriculum map and maintenance notes, see [`docs/keyquest-curriculu
 
 The original `xion.typ` script was written by Hideyuki Mori of Ayane International Inc.
 
-The `keyquest.typ` script adapts KeyQuest lesson content for GNU Typist.
+The `keyquest.typ` script adapts and extends KeyQuest lesson content for GNU Typist.

--- a/docs/keyquest-curriculum.md
+++ b/docs/keyquest-curriculum.md
@@ -1,8 +1,8 @@
 # KeyQuest Curriculum for GNU Typist
 
-This manual explains how `keyquest.typ` adapts the first 28 implemented KeyQuest lessons to GNU Typist.
+This manual explains how `keyquest.typ` presents a 90-day KeyQuest typing journey in GNU Typist.
 
-KeyQuest is designed as a terminal typing adventure. Its source lessons are JSON files with metadata, target keys, skill tracks, finger hints, and English prompts. GNU Typist uses a compact `.typ` script language, so this port turns the same curriculum into menus, banners, text notes, key introductions, and drill lines.
+Days 1-28 preserve implemented KeyQuest lesson prompts where they fit GNU Typist. Days 29-90 are gtypist-native curriculum extensions based on KeyQuest quest map names, ranges, and themes; they are not bundled KeyQuest JSON lessons.
 
 ## How to Run
 
@@ -14,83 +14,194 @@ Choose an arc from the main menu, then choose a day. The lesson returns to its a
 
 ## Adaptation Rules
 
-- Each KeyQuest JSON lesson became one GNU Typist lesson block.
-- KeyQuest prompt text remains English.
+- Each day becomes one GNU Typist lesson block.
+- Typing prompts remain English.
 - Very short prompts are repeated on a drill line so gtypist practice is not too brief.
-- `targetKeys` metadata becomes the gtypist `I:` key group for each drill.
+- Day 29-90 key groups are derived from their gtypist drill text.
 - RPG systems such as XP, HP, MP, inventory, story gates, and achievements are not simulated in gtypist.
 - Story flavor is kept as concise training framing so the screen stays calm while typing.
 
 ## Practice Philosophy
 
-The first KeyQuest month is accuracy-first. Type slowly enough that each finger returns to home position after every reach. Do not chase speed during the early lessons. Repeat a day when the hand shape feels unstable.
+The full journey is accuracy-first. Type slowly enough that each finger returns to home position after every reach. Later speed and pressure arcs still treat accuracy as the foundation.
 
 ## Arc Overview
 
 ### Novice Hall (Days 1-7)
 
-The first week is intentionally stubborn: small patterns, mirrored pairs, home-row ownership, and accuracy before speed.
+Home position, finger ownership, mirrored pairs, and accuracy before speed.
 
-- Day 01: Novice Hall: Home Position - Learn the calm home stance and anchor both index fingers on f and j. Focus: home position, left index, right index, home row accuracy.
-- Day 02: Novice Hall: Left And Right Balance - Balance left and right hands without rushing the home row. Focus: left hand balance, right hand balance, home row rhythm.
-- Day 03: Novice Hall: Finger Responsibility - Reinforce which finger owns each home-row key. Focus: finger responsibility, home row ownership, calm correction.
-- Day 04: Novice Hall: Rhythm Hall - Build a steady cadence with familiar home-row combinations. Focus: home row rhythm, spacing, steady cadence.
-- Day 05: Novice Hall: First Words - Connect home-row drills to tiny readable English word groups. Focus: short words, home row posture, word accuracy.
-- Day 06: Novice Hall: Repair The Stance - Repair weak-finger habits with slow, accurate review. Focus: weak finger repair, slow perfect typing, home row recovery.
-- Day 07: Novice Hall: Gatekeeper Trial - Prove the first-week home-row basics in a gatekeeper trial. Focus: home row trial, accuracy check, calm recovery.
+- Day 01: Novice Hall: Home Position - Learn the calm home stance and anchor both index fingers on f and j.
+- Day 02: Novice Hall: Left And Right Balance - Balance left and right hands without rushing the home row.
+- Day 03: Novice Hall: Finger Responsibility - Reinforce which finger owns each home-row key.
+- Day 04: Novice Hall: Rhythm Hall - Build a steady cadence with familiar home-row combinations.
+- Day 05: Novice Hall: First Words - Connect home-row drills to tiny readable English word groups.
+- Day 06: Novice Hall: Repair The Stance - Repair weak-finger habits with slow, accurate review.
+- Day 07: Novice Hall: Gatekeeper Trial - Prove the first-week home-row basics in a gatekeeper trial.
 
 ### Meadow Road (Days 8-14)
 
-The second week expands into nearby top-row keys while repeatedly returning the hands to home position.
+Top-row reach while repeatedly returning the hands home.
 
-- Day 08: Meadow Road: First Steps Beyond Home - Step beyond home row with r, u, e, and i while returning home. Focus: vertical movement, nearby top row keys, return to home.
-- Day 09: Meadow Road: Ring Finger Reach - Practice ring-finger top-row reach with w and o. Focus: ring finger reach, w and o, return to home.
-- Day 10: Meadow Road: Index Reach - Practice index-finger reach with t and y in short patterns. Focus: index reach, t and y, controlled stretch.
-- Day 11: Meadow Road: Outer Watch - Add the outer pinky top-row keys q and p carefully. Focus: outer reach, q and p, return to home.
-- Day 12: Meadow Road: Top Row Trail - Travel across the top row in short lateral patterns. Focus: top row travel, lateral control, steady return.
-- Day 13: Meadow Road: First Flow - Type short English word flow using home row and top row. Focus: short word flow, top row words, calm rhythm.
-- Day 14: Meadow Road: Waystone Trial - Check top-row control in a deliberate Waystone Trial. Focus: weekly checkpoint, top row control, accuracy under pressure.
+- Day 08: Meadow Road: First Steps Beyond Home - Step beyond home row with r, u, e, and i while returning home.
+- Day 09: Meadow Road: Ring Finger Reach - Practice ring-finger top-row reach with w and o.
+- Day 10: Meadow Road: Index Reach - Practice index-finger reach with t and y in short patterns.
+- Day 11: Meadow Road: Outer Watch - Add the outer pinky top-row keys q and p carefully.
+- Day 12: Meadow Road: Top Row Trail - Travel across the top row in short lateral patterns.
+- Day 13: Meadow Road: First Flow - Type short English word flow using home row and top row.
+- Day 14: Meadow Road: Waystone Trial - Check top-row control in a deliberate Waystone Trial.
 
 ### River Gate (Days 15-21)
 
-The third week adds bottom-row movement, bridge letters, and the first punctuation checkpoint.
+Bottom-row movement, bridge letters, and punctuation control.
 
-- Day 15: River Gate: Lower Step - Introduce lower-step movement with c and m. Focus: bottom row introduction, c and m, return to home.
-- Day 16: River Gate: Valley Reach - Practice valley reach with v and n while keeping hands quiet. Focus: bottom row reach, v and n, index control.
-- Day 17: River Gate: Bridge Keys - Bridge rows around b, g, and h without drifting from home. Focus: index bridge, b and g h, center control.
-- Day 18: River Gate: Comma And Period - Add comma and period practice with the right hand. Focus: comma, period, right-hand punctuation.
-- Day 19: River Gate: Bottom Row Words - Use bottom-row words inside short readable phrases. Focus: bottom row words, mixed rows, accuracy.
-- Day 20: River Gate: Current Review - Review mixed rows and punctuation with calm recovery. Focus: mixed-row review, punctuation review, steady cadence.
-- Day 21: River Gate: Ferryman Trial - Cross the Ferryman Trial for bottom-row and punctuation control. Focus: weekly checkpoint, bottom row control, punctuation under pressure.
+- Day 15: River Gate: Lower Step - Introduce lower-step movement with c and m.
+- Day 16: River Gate: Valley Reach - Practice valley reach with v and n while keeping hands quiet.
+- Day 17: River Gate: Bridge Keys - Bridge rows around b, g, and h without drifting from home.
+- Day 18: River Gate: Comma And Period - Add comma and period practice with the right hand.
+- Day 19: River Gate: Bottom Row Words - Use bottom-row words inside short readable phrases.
+- Day 20: River Gate: Current Review - Review mixed rows and punctuation with calm recovery.
+- Day 21: River Gate: Ferryman Trial - Cross the Ferryman Trial for bottom-row and punctuation control.
 
 ### Lantern Keep (Days 22-28)
 
-The fourth week introduces digits in small groups before mixing them into readable English prompts.
+Number-row reach and practical mixed digit prompts.
 
-- Day 22: Lantern Keep: Left Number Row - Introduce the left number row with 1, 2, 3, and 4. Focus: left number row, upper reach, accuracy.
-- Day 23: Lantern Keep: Right Number Row - Introduce the right number row with 7, 8, 9, and 0. Focus: right number row, upper reach, rhythm.
-- Day 24: Lantern Keep: Center Span - Practice the center number span with 4, 5, 6, and 7. Focus: center number row, index reach, steady return.
-- Day 25: Lantern Keep: Counts And Codes - Type short counts and codes without losing home-position shape. Focus: number words, short codes, accuracy under context.
-- Day 26: Lantern Keep: Map Marks - Practice map labels and room numbers as practical digit prompts. Focus: map labels, mixed rows, number accuracy.
-- Day 27: Lantern Keep: Mixed Signals - Mix number-row instructions while keeping rhythm stable. Focus: mixed number row, short instructions, steady cadence.
-- Day 28: Lantern Keep: Beacon Trial - Clear the Beacon Trial for number-row control. Focus: weekly checkpoint, number row control, mixed instruction accuracy.
+- Day 22: Lantern Keep: Left Number Row - Introduce the left number row with 1, 2, 3, and 4.
+- Day 23: Lantern Keep: Right Number Row - Introduce the right number row with 7, 8, 9, and 0.
+- Day 24: Lantern Keep: Center Span - Practice the center number span with 4, 5, 6, and 7.
+- Day 25: Lantern Keep: Counts And Codes - Type short counts and codes without losing home-position shape.
+- Day 26: Lantern Keep: Map Marks - Practice map labels and room numbers as practical digit prompts.
+- Day 27: Lantern Keep: Mixed Signals - Mix number-row instructions while keeping rhythm stable.
+- Day 28: Lantern Keep: Beacon Trial - Clear the Beacon Trial for number-row control.
+
+### Ashen Forge (Days 29-35)
+
+Shift keys, capital letters, names, sentence starts, and title-case control.
+
+- Day 29: Ashen Forge: Left Shift Spark - Introduce left Shift through single capital letters.
+- Day 30: Ashen Forge: Right Shift Spark - Introduce right Shift through capital letters.
+- Day 31: Ashen Forge: Capital Names - Type short proper names with calm Shift control.
+- Day 32: Ashen Forge: Sentence Starts - Practice capital letters at sentence starts.
+- Day 33: Ashen Forge: Title Case - Build title-case control with short fantasy phrases.
+- Day 34: Ashen Forge: Shift Review - Review both Shift keys with mixed words.
+- Day 35: Ashen Forge: Anvil Trial - Clear the Anvil Trial with capital control.
+
+### Windspire (Days 36-42)
+
+Controlled pace, rhythm, bursts, longer cadence, and punctuation as breath marks.
+
+- Day 36: Windspire: Even Steps - Build an even rhythm with familiar words.
+- Day 37: Windspire: Short Bursts - Practice short controlled bursts without racing.
+- Day 38: Windspire: Long Cadence - Hold stable cadence across longer word groups.
+- Day 39: Windspire: Alternate Pace - Alternate slow and brisk patterns.
+- Day 40: Windspire: Breath Marks - Use commas and periods as rhythm marks.
+- Day 41: Windspire: Gale Review - Review rhythm with mixed rows and numbers.
+- Day 42: Windspire: Gale Trial - Clear the Gale Trial with controlled speed.
+
+### Clockwork Citadel (Days 43-49)
+
+Programmer pairs: parentheses, brackets, braces, angle brackets, and nesting.
+
+- Day 43: Clockwork Citadel: Parentheses - Introduce parentheses as paired gates.
+- Day 44: Clockwork Citadel: Brackets - Practice square brackets in short labels.
+- Day 45: Clockwork Citadel: Braces - Practice braces with code-like fragments.
+- Day 46: Clockwork Citadel: Angle Gates - Practice angle brackets without rushing.
+- Day 47: Clockwork Citadel: Nested Pairs - Combine paired symbols in nested patterns.
+- Day 48: Clockwork Citadel: Gear Review - Review all bracket pairs with words.
+- Day 49: Clockwork Citadel: Gearheart Trial - Clear the Gearheart Trial with bracket control.
+
+### Starfall Library (Days 50-56)
+
+Symbols, operators, quotes, colon patterns, and readable code-like flow.
+
+- Day 50: Starfall Library: Math Signs - Introduce simple operator signs.
+- Day 51: Starfall Library: Slash And Star - Practice slash and star symbols.
+- Day 52: Starfall Library: Quotes - Use quotes around short words.
+- Day 53: Starfall Library: Colon Signals - Practice colon and semicolon notes.
+- Day 54: Starfall Library: Code Words - Combine symbols with code-like English.
+- Day 55: Starfall Library: Archive Review - Review operators and punctuation.
+- Day 56: Starfall Library: Archivist Trial - Clear the Archivist Trial with symbol flow.
+
+### Dragon Spine (Days 57-63)
+
+Longer phrases and accuracy under pressure before speed reward.
+
+- Day 57: Dragon Spine: Pressure Warmup - Begin pressure practice with clean resets.
+- Day 58: Dragon Spine: Longer Climb - Climb through longer phrases.
+- Day 59: Dragon Spine: Heat Control - Keep control with capitals and numbers.
+- Day 60: Dragon Spine: No Panic - Practice recovery after dense punctuation.
+- Day 61: Dragon Spine: Focus Run - Hold attention through connected sentences.
+- Day 62: Dragon Spine: Wyrm Review - Review pressure with mixed content.
+- Day 63: Dragon Spine: Wyrm Trial - Clear the Wyrm Trial with accuracy first.
+
+### Moonlit Labyrinth (Days 64-70)
+
+Weak-key recovery, outer reaches, bottom-row repair, and calm correction.
+
+- Day 64: Moonlit Labyrinth: Slow Repair - Return to slow correction and weak-key awareness.
+- Day 65: Moonlit Labyrinth: Outer Keys - Target outer reaches that often become weak.
+- Day 66: Moonlit Labyrinth: Bottom Repair - Repair bottom-row hesitation.
+- Day 67: Moonlit Labyrinth: Symbol Repair - Review symbols slowly.
+- Day 68: Moonlit Labyrinth: Mirror Paths - Use mirrored phrases to expose uneven hands.
+- Day 69: Moonlit Labyrinth: Labyrinth Review - Review mixed weak-key prompts.
+- Day 70: Moonlit Labyrinth: Minotaur Trial - Clear the Minotaur Trial by recovering cleanly.
+
+### Obsidian Throne (Days 71-77)
+
+Mixed punctuation, quotes, clauses, and long-form focus.
+
+- Day 71: Obsidian Throne: Mixed Marks - Introduce denser punctuation.
+- Day 72: Obsidian Throne: Quote Orders - Practice quoted commands.
+- Day 73: Obsidian Throne: Long Focus - Hold focus through punctuation-rich phrases.
+- Day 74: Obsidian Throne: Clause Chains - Practice clauses joined by punctuation.
+- Day 75: Obsidian Throne: Dense Review - Review punctuation, capitals, and numbers.
+- Day 76: Obsidian Throne: Crown Approach - Prepare for the crown trial.
+- Day 77: Obsidian Throne: Crown Trial - Clear the Crown Trial with long-form focus.
+
+### Dawn Citadel (Days 78-84)
+
+Full-keyboard mastery review across rows, capitals, numbers, symbols, and recovery.
+
+- Day 78: Dawn Citadel: Full Keyboard Scan - Review the full keyboard in organized bands.
+- Day 79: Dawn Citadel: Capital Review - Review capitals in full-keyboard phrases.
+- Day 80: Dawn Citadel: Symbol Review - Review symbols and brackets.
+- Day 81: Dawn Citadel: Phrase Review - Type longer phrases with previous skills.
+- Day 82: Dawn Citadel: Recovery Review - Return to hard keys and correct them calmly.
+- Day 83: Dawn Citadel: Final Review - Mix rows, capitals, numbers, and punctuation.
+- Day 84: Dawn Citadel: Dawn Trial - Clear the Dawn Trial as a mastery review.
+
+### Final Gate (Days 85-90)
+
+A 6-day final integrated quest ending with the Last Spell Trial.
+
+- Day 85: Final Gate: First Seal - Begin the final integrated quest.
+- Day 86: Final Gate: Second Seal - Mix capitals, numbers, and punctuation.
+- Day 87: Final Gate: Third Seal - Use code-like patterns inside final text.
+- Day 88: Final Gate: Fourth Seal - Hold long-form focus through final sentences.
+- Day 89: Final Gate: Last Camp - Review the full journey before the final trial.
+- Day 90: Final Gate: Last Spell Trial - Complete the final integrated typing quest.
+
+## Source Notes
+
+- Days 1-28 preserve the implemented KeyQuest lesson prompts where they fit GNU Typist.
+- Days 29-90 follow the quest map arc themes from KeyQuest and are authored directly for gtypist.
+- The naming follows the implemented KeyQuest quest map when it differs from older planning documents.
 
 ## File Map
 
-- `keyquest.typ`: GNU Typist script for the KeyQuest 28-day journey.
+- `keyquest.typ`: GNU Typist script for the full 90-day KeyQuest journey.
 - `xion.typ`: original weak-finger etude script, kept unchanged.
 - `README.md`: installation and quick usage guide.
 - `docs/keyquest-curriculum.md`: this curriculum manual.
 
 ## Maintaining Future Lessons
 
-When new KeyQuest lessons are added, keep the gtypist version small and explicit:
-
-1. Add the day to the appropriate arc menu or create a new arc menu.
+1. Add or update the day in the appropriate arc menu.
 2. Add one `*:DAY_NN` label for the lesson.
 3. Use `B:` for the day title and `T:` lines for the practice goal.
 4. Use `I:` to introduce target keys before each drill.
 5. Use `D:` and continuation lines starting with ` :` for the actual typing text.
 6. End the lesson with `G:` back to the arc menu.
 
-Keep drill lines readable in a normal terminal. If a KeyQuest prompt is extremely short, repeat it several times. If it is long, split it into multiple gtypist continuation lines.
+Keep drill lines readable in a normal terminal. If a prompt is extremely short, repeat it several times. If it is long, split it into multiple gtypist continuation lines.

--- a/keyquest.typ
+++ b/keyquest.typ
@@ -4,6 +4,15 @@ M: "KeyQuest Typing Journey"
  :MEADOW_ROAD  "Meadow Road"
  :RIVER_GATE  "River Gate"
  :LANTERN_KEEP  "Lantern Keep"
+ :ASHEN_FORGE  "Ashen Forge"
+ :WINDSPIRE  "Windspire"
+ :CLOCKWORK_CITADEL  "Clockwork Citadel"
+ :STARFALL_LIBRARY  "Starfall Library"
+ :DRAGON_SPINE  "Dragon Spine"
+ :MOONLIT_LABYRINTH  "Moonlit Labyrinth"
+ :OBSIDIAN_THRONE  "Obsidian Throne"
+ :DAWN_CITADEL  "Dawn Citadel"
+ :FINAL_GATE  "Final Gate"
  :ABOUT  "About this script"
  :EXIT  "Exit"
 
@@ -49,6 +58,104 @@ M: "Lantern Keep"
  :DAY_26  "Day 26: Map Marks"
  :DAY_27  "Day 27: Mixed Signals"
  :DAY_28  "Day 28: Beacon Trial"
+ :MENU  "Back to arc menu"
+
+*:ASHEN_FORGE
+M: "Ashen Forge"
+ :DAY_29  "Day 29: Left Shift Spark"
+ :DAY_30  "Day 30: Right Shift Spark"
+ :DAY_31  "Day 31: Capital Names"
+ :DAY_32  "Day 32: Sentence Starts"
+ :DAY_33  "Day 33: Title Case"
+ :DAY_34  "Day 34: Shift Review"
+ :DAY_35  "Day 35: Anvil Trial"
+ :MENU  "Back to arc menu"
+
+*:WINDSPIRE
+M: "Windspire"
+ :DAY_36  "Day 36: Even Steps"
+ :DAY_37  "Day 37: Short Bursts"
+ :DAY_38  "Day 38: Long Cadence"
+ :DAY_39  "Day 39: Alternate Pace"
+ :DAY_40  "Day 40: Breath Marks"
+ :DAY_41  "Day 41: Gale Review"
+ :DAY_42  "Day 42: Gale Trial"
+ :MENU  "Back to arc menu"
+
+*:CLOCKWORK_CITADEL
+M: "Clockwork Citadel"
+ :DAY_43  "Day 43: Parentheses"
+ :DAY_44  "Day 44: Brackets"
+ :DAY_45  "Day 45: Braces"
+ :DAY_46  "Day 46: Angle Gates"
+ :DAY_47  "Day 47: Nested Pairs"
+ :DAY_48  "Day 48: Gear Review"
+ :DAY_49  "Day 49: Gearheart Trial"
+ :MENU  "Back to arc menu"
+
+*:STARFALL_LIBRARY
+M: "Starfall Library"
+ :DAY_50  "Day 50: Math Signs"
+ :DAY_51  "Day 51: Slash And Star"
+ :DAY_52  "Day 52: Quotes"
+ :DAY_53  "Day 53: Colon Signals"
+ :DAY_54  "Day 54: Code Words"
+ :DAY_55  "Day 55: Archive Review"
+ :DAY_56  "Day 56: Archivist Trial"
+ :MENU  "Back to arc menu"
+
+*:DRAGON_SPINE
+M: "Dragon Spine"
+ :DAY_57  "Day 57: Pressure Warmup"
+ :DAY_58  "Day 58: Longer Climb"
+ :DAY_59  "Day 59: Heat Control"
+ :DAY_60  "Day 60: No Panic"
+ :DAY_61  "Day 61: Focus Run"
+ :DAY_62  "Day 62: Wyrm Review"
+ :DAY_63  "Day 63: Wyrm Trial"
+ :MENU  "Back to arc menu"
+
+*:MOONLIT_LABYRINTH
+M: "Moonlit Labyrinth"
+ :DAY_64  "Day 64: Slow Repair"
+ :DAY_65  "Day 65: Outer Keys"
+ :DAY_66  "Day 66: Bottom Repair"
+ :DAY_67  "Day 67: Symbol Repair"
+ :DAY_68  "Day 68: Mirror Paths"
+ :DAY_69  "Day 69: Labyrinth Review"
+ :DAY_70  "Day 70: Minotaur Trial"
+ :MENU  "Back to arc menu"
+
+*:OBSIDIAN_THRONE
+M: "Obsidian Throne"
+ :DAY_71  "Day 71: Mixed Marks"
+ :DAY_72  "Day 72: Quote Orders"
+ :DAY_73  "Day 73: Long Focus"
+ :DAY_74  "Day 74: Clause Chains"
+ :DAY_75  "Day 75: Dense Review"
+ :DAY_76  "Day 76: Crown Approach"
+ :DAY_77  "Day 77: Crown Trial"
+ :MENU  "Back to arc menu"
+
+*:DAWN_CITADEL
+M: "Dawn Citadel"
+ :DAY_78  "Day 78: Full Keyboard Scan"
+ :DAY_79  "Day 79: Capital Review"
+ :DAY_80  "Day 80: Symbol Review"
+ :DAY_81  "Day 81: Phrase Review"
+ :DAY_82  "Day 82: Recovery Review"
+ :DAY_83  "Day 83: Final Review"
+ :DAY_84  "Day 84: Dawn Trial"
+ :MENU  "Back to arc menu"
+
+*:FINAL_GATE
+M: "Final Gate"
+ :DAY_85  "Day 85: First Seal"
+ :DAY_86  "Day 86: Second Seal"
+ :DAY_87  "Day 87: Third Seal"
+ :DAY_88  "Day 88: Fourth Seal"
+ :DAY_89  "Day 89: Last Camp"
+ :DAY_90  "Day 90: Last Spell Trial"
  :MENU  "Back to arc menu"
 
 *:DAY_01
@@ -526,17 +633,975 @@ D:the beacon opens at level 28. the beacon opens at level 28.
 
 G:LANTERN_KEEP
 
+*:DAY_29
+B:KeyQuest - Day 29 - Ashen Forge: Left Shift Spark
+T:Introduce left Shift through single capital letters.
+ :Arc: Ashen Forge. Shift keys and capital letters.
+ :Focus: Shift keys and capital letters, left shift spark.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)A&S&D&F - ashen_forge-29-1
+D:A S D F A S D F A S D F A S D F A S D F A S D F A S D F A S D F
+I:(2)A&a&S&s&D&d&F&f - ashen_forge-29-2
+D:A a S s D d F f A a S s D d F f A a S s D d F f A a S s D d F f
+I:(3)A&s&k&D&a&d&F&l&S&f&e - ashen_forge-29-3
+D:Ask Dad Fall Safe Ask Dad Fall Safe Ask Dad Fall Safe
+
+G:ASHEN_FORGE
+
+*:DAY_30
+B:KeyQuest - Day 30 - Ashen Forge: Right Shift Spark
+T:Introduce right Shift through capital letters.
+ :Arc: Ashen Forge. Shift keys and capital letters.
+ :Focus: Shift keys and capital letters, right shift spark.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)J&K&L&H - ashen_forge-30-1
+D:J K L H J K L H J K L H J K L H J K L H J K L H J K L H J K L H
+I:(2)J&j&K&k&L&l&H&h - ashen_forge-30-2
+D:J j K k L l H h J j K k L l H h J j K k L l H h J j K k L l H h
+I:(3)J&o&y&K&e&L&a&k&H&i&l - ashen_forge-30-3
+D:Joy Key Lake Hill Joy Key Lake Hill Joy Key Lake Hill
+
+G:ASHEN_FORGE
+
+*:DAY_31
+B:KeyQuest - Day 31 - Ashen Forge: Capital Names
+T:Type short proper names with calm Shift control.
+ :Arc: Ashen Forge. Shift keys and capital letters.
+ :Focus: Shift keys and capital letters, capital names.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)A&d&a&K&e&n&L&i&J&o - ashen_forge-31-1
+D:Ada Ken Lia Jo Ada Ken Lia Jo Ada Ken Lia Jo Ada Ken Lia Jo
+I:(2)M&i&r&a&N&o&V&l&e&O&w&n - ashen_forge-31-2
+D:Mira Nora Vale Owen Mira Nora Vale Owen Mira Nora Vale Owen
+I:(3)A&d&a&n&K&e&r - ashen_forge-31-3
+D:Ada and Ken read Ada and Ken read Ada and Ken read Ada and Ken read
+
+G:ASHEN_FORGE
+
+*:DAY_32
+B:KeyQuest - Day 32 - Ashen Forge: Sentence Starts
+T:Practice capital letters at sentence starts.
+ :Arc: Ashen Forge. Shift keys and capital letters.
+ :Focus: Shift keys and capital letters, sentence starts.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)K&e&p&c&a&l&m&.&H&o&d&h - ashen_forge-32-1
+D:Keep calm. Hold home. Type true.
+I:(2)T&h&e&f&o&r&g&l&w&s&.&k - ashen_forge-32-2
+D:The forge glows. The key cools.
+I:(3)S&t&a&r&e&c&h&l&i&n&w&. - ashen_forge-32-3
+D:Start each line with care.
+
+G:ASHEN_FORGE
+
+*:DAY_33
+B:KeyQuest - Day 33 - Ashen Forge: Title Case
+T:Build title-case control with short fantasy phrases.
+ :Arc: Ashen Forge. Shift keys and capital letters.
+ :Focus: Shift keys and capital letters, title case.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)A&s&h&e&n&F&o&r&g - ashen_forge-33-1
+D:Ashen Forge Ashen Forge Ashen Forge Ashen Forge Ashen Forge
+I:(2)S&i&l&v&e&r&K&y&Q&u&t&G - ashen_forge-33-2
+D:Silver Key Quiet Gate Silver Key Quiet Gate Silver Key Quiet Gate
+I:(3)T&h&e&B&r&i&g&t&A&n&v&l - ashen_forge-33-3
+D:The Bright Anvil Shapes The Silent Key
+
+G:ASHEN_FORGE
+
+*:DAY_34
+B:KeyQuest - Day 34 - Ashen Forge: Shift Review
+T:Review both Shift keys with mixed words.
+ :Arc: Ashen Forge. Shift keys and capital letters.
+ :Focus: Shift keys and capital letters, shift review.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)A&j&S&k&D&l&F&h - ashen_forge-34-1
+D:A j S k D l F h A j S k D l F h A j S k D l F h A j S k D l F h
+I:(2)C&a&l&m&H&n&d&s&S&h&p&e - ashen_forge-34-2
+D:Calm Hands Shape Bright Keys
+I:(3)A&s&t&e&a&d&y&h&n&c&l&i - ashen_forge-34-3
+D:A steady hand can lift every letter.
+
+G:ASHEN_FORGE
+
+*:DAY_35
+B:KeyQuest - Day 35 - Ashen Forge: Anvil Trial
+T:Clear the Anvil Trial with capital control.
+ :Arc: Ashen Forge. Shift keys and capital letters.
+ :Focus: Shift keys and capital letters, anvil trial.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)A&S&D&F&J&K&L&H - ashen_forge-35-1
+D:A S D F J K L H A S D F J K L H A S D F J K L H A S D F J K L H
+I:(2)A&d&a&K&e&n&M&i&r&O&w - ashen_forge-35-2
+D:Ada Ken Mira Owen Ada Ken Mira Owen Ada Ken Mira Owen
+I:(3)T&h&e&A&s&n&F&o&r&g&a&p - ashen_forge-35-3
+D:The Ashen Forge shapes a calm bright key.
+I:(4)H&o&l&d&h&m&e&,&t&a&p&S - ashen_forge-35-4
+D:Hold home, tap Shift, and let the anvil ring.
+
+G:ASHEN_FORGE
+
+*:DAY_36
+B:KeyQuest - Day 36 - Windspire: Even Steps
+T:Build an even rhythm with familiar words.
+ :Arc: Windspire. speed control and rhythm.
+ :Focus: speed control and rhythm, even steps.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)t&a&p&r&e&s - windspire-36-1
+D:tap rest tap rest tap rest tap rest tap rest tap rest
+I:(2)c&a&l&m&p&e&s&t&d&y - windspire-36-2
+D:calm pace steady pace calm pace steady pace calm pace steady pace
+I:(3)E&v&e&r&y&s&m&a&l&t&p&k - windspire-36-3
+D:Every small step keeps the wind in time.
+
+G:WINDSPIRE
+
+*:DAY_37
+B:KeyQuest - Day 37 - Windspire: Short Bursts
+T:Practice short controlled bursts without racing.
+ :Arc: Windspire. speed control and rhythm.
+ :Focus: speed control and rhythm, short bursts.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)f&a&s&t&o&p&c&l&m&g - windspire-37-1
+D:fast stop calm go fast stop calm go fast stop calm go
+I:(2)w&i&n&d&r&u&s&t&h&e - windspire-37-2
+D:wind runs then rests wind runs then rests wind runs then rests
+I:(3)B&u&r&s&t&f&o&a&m&e&n&, - windspire-37-3
+D:Burst for a moment, then return to calm hands.
+
+G:WINDSPIRE
+
+*:DAY_38
+B:KeyQuest - Day 38 - Windspire: Long Cadence
+T:Hold stable cadence across longer word groups.
+ :Arc: Windspire. speed control and rhythm.
+ :Focus: speed control and rhythm, long cadence.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)t&h&e&w&i&n&d&c&a&r&s&q - windspire-38-1
+D:the wind carries a quiet rhythm over the road
+I:(2)s&t&e&a&d&y&f&i&n&g&r&c - windspire-38-2
+D:steady fingers cross the high bridge with care
+I:(3)p&a&c&e&t&h&l&i&n&s&o&v - windspire-38-3
+D:pace the line so every word lands cleanly
+
+G:WINDSPIRE
+
+*:DAY_39
+B:KeyQuest - Day 39 - Windspire: Alternate Pace
+T:Alternate slow and brisk patterns.
+ :Arc: Windspire. speed control and rhythm.
+ :Focus: speed control and rhythm, alternate pace.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)s&l&o&w&q&u&i&c&k - windspire-39-1
+D:slow slow quick quick slow slow quick quick slow slow quick quick
+I:(2)c&a&l&m&b&r&i&g&h&t - windspire-39-2
+D:calm calm bright bright calm calm bright bright
+I:(3)C&h&a&n&g&e&p&c&o&l&y&w - windspire-39-3
+D:Change pace only when the hands stay quiet.
+
+G:WINDSPIRE
+
+*:DAY_40
+B:KeyQuest - Day 40 - Windspire: Breath Marks
+T:Use commas and periods as rhythm marks.
+ :Arc: Windspire. speed control and rhythm.
+ :Focus: speed control and rhythm, breath marks.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)b&r&e&a&t&h&,&y&p&u&s&. - windspire-40-1
+D:breathe, type, pause. breathe, type, pause.
+I:(2)s&h&o&r&t&w&i&n&d&,&l&g - windspire-40-2
+D:short wind, long road. calm hands, clean words.
+I:(3)L&e&t&a&c&h&o&m&s&l&w&r - windspire-40-3
+D:Let each comma slow the run.
+
+G:WINDSPIRE
+
+*:DAY_41
+B:KeyQuest - Day 41 - Windspire: Gale Review
+T:Review rhythm with mixed rows and numbers.
+ :Arc: Windspire. speed control and rhythm.
+ :Focus: speed control and rhythm, gale review.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)q&w&e&r&a&s&d&f&z&x&c&v - windspire-41-1
+D:qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv
+I:(2)u&i&o&p&j&k&l&;&n&m&,&. - windspire-41-2
+D:uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,.
+I:(3)s&t&e&a&d&y&p&c&o&v&r&1 - windspire-41-3
+D:steady pace over 12 stones and 34 rails
+
+G:WINDSPIRE
+
+*:DAY_42
+B:KeyQuest - Day 42 - Windspire: Gale Trial
+T:Clear the Gale Trial with controlled speed.
+ :Arc: Windspire. speed control and rhythm.
+ :Focus: speed control and rhythm, gale trial.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)t&a&p&r&e&s&q&u&i&c&k&l - windspire-42-1
+D:tap rest quick calm tap rest quick calm tap rest quick calm
+I:(2)t&h&e&w&i&n&d&r&s&b&u&a - windspire-42-2
+D:the wind rises but the hands stay steady
+I:(3)q&u&i&c&k&s&t&e&p&a&r&f - windspire-42-3
+D:quick steps are useful only when accuracy holds
+I:(4)r&i&d&e&t&h&g&a&l&w&y&m - windspire-42-4
+D:ride the gale with rhythm, not panic.
+
+G:WINDSPIRE
+
+*:DAY_43
+B:KeyQuest - Day 43 - Clockwork Citadel: Parentheses
+T:Introduce parentheses as paired gates.
+ :Arc: Clockwork Citadel. programmer pairs and brackets.
+ :Focus: programmer pairs and brackets, parentheses.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)(&) - clockwork_citadel-43-1
+D:( ) () ( ) () ( ) () ( ) () ( ) () ( ) () ( ) () ( ) () ( ) ()
+I:(2)(&a&)&k&e&y&m&p - clockwork_citadel-43-2
+D:(a) (key) (map) (a) (key) (map) (a) (key) (map) (a) (key) (map)
+I:(3)o&p&e&n&(&t&h&g&a&)&d&c - clockwork_citadel-43-3
+D:open (the gate) and close (the lock)
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_44
+B:KeyQuest - Day 44 - Clockwork Citadel: Brackets
+T:Practice square brackets in short labels.
+ :Arc: Clockwork Citadel. programmer pairs and brackets.
+ :Focus: programmer pairs and brackets, brackets.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)[&] - clockwork_citadel-44-1
+D:[ ] [] [ ] [] [ ] [] [ ] [] [ ] [] [ ] [] [ ] [] [ ] [] [ ] []
+I:(2)[&1&]&2&k&e&y - clockwork_citadel-44-2
+D:[1] [2] [key] [1] [2] [key] [1] [2] [key] [1] [2] [key]
+I:(3)m&a&r&k&[&o&]&t&h&e&n&d - clockwork_citadel-44-3
+D:mark [room] then read [signal]
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_45
+B:KeyQuest - Day 45 - Clockwork Citadel: Braces
+T:Practice braces with code-like fragments.
+ :Arc: Clockwork Citadel. programmer pairs and brackets.
+ :Focus: programmer pairs and brackets, braces.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1){&} - clockwork_citadel-45-1
+D:{ } {} { } {} { } {} { } {} { } {} { } {} { } {} { } {} { } {}
+I:(2){&k&e&y&}&g&a&t&m&p - clockwork_citadel-45-2
+D:{key} {gate} {map} {key} {gate} {map} {key} {gate} {map}
+I:(3)s&t&o&r&e&{&l&i&g&h&}&b - clockwork_citadel-45-3
+D:store {light} before {shadow}
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_46
+B:KeyQuest - Day 46 - Clockwork Citadel: Angle Gates
+T:Practice angle brackets without rushing.
+ :Arc: Clockwork Citadel. programmer pairs and brackets.
+ :Focus: programmer pairs and brackets, angle gates.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)<&> - clockwork_citadel-46-1
+D:< > <> < > <> < > <> < > <> < > <> < > <> < > <> < > <> < > <>
+I:(2)<&k&e&y&>&g&a&t&p&h - clockwork_citadel-46-2
+D:<key> <gate> <path> <key> <gate> <path> <key> <gate> <path>
+I:(3)r&e&a&d&<&s&i&g&n&l&>&b - clockwork_citadel-46-3
+D:read <signal> before <system> moves
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_47
+B:KeyQuest - Day 47 - Clockwork Citadel: Nested Pairs
+T:Combine paired symbols in nested patterns.
+ :Arc: Clockwork Citadel. programmer pairs and brackets.
+ :Focus: programmer pairs and brackets, nested pairs.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)(&[&]&)&{&} - clockwork_citadel-47-1
+D:([]) ({}) ([]) ({}) ([]) ({}) ([]) ({}) ([]) ({}) ([]) ({})
+I:(2)[&m&a&p&]&(&r&o&)&{&k&e - clockwork_citadel-47-2
+D:[map](room) {key} [map](room) {key} [map](room) {key}
+I:(3)o&p&e&n&(&[&q&u&i&t&]&) - clockwork_citadel-47-3
+D:open ([quiet]) gears with {steady} hands
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_48
+B:KeyQuest - Day 48 - Clockwork Citadel: Gear Review
+T:Review all bracket pairs with words.
+ :Arc: Clockwork Citadel. programmer pairs and brackets.
+ :Focus: programmer pairs and brackets, gear review.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)(&)&[&]&{&}&<&> - clockwork_citadel-48-1
+D:() [] {} <> () [] {} <> () [] {} <> () [] {} <> () [] {} <>
+I:(2)g&e&a&r&[&1&]&t&u&n&s&( - clockwork_citadel-48-2
+D:gear[1] turns (slow) while {hands} return
+I:(3)c&l&o&k&w&r&e&y&s&n&d&p - clockwork_citadel-48-3
+D:clockwork keys need paired symbols in order
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_49
+B:KeyQuest - Day 49 - Clockwork Citadel: Gearheart Trial
+T:Clear the Gearheart Trial with bracket control.
+ :Arc: Clockwork Citadel. programmer pairs and brackets.
+ :Focus: programmer pairs and brackets, gearheart trial.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)(&)&[&]&{&}&<&> - clockwork_citadel-49-1
+D:() [] {} <> () [] {} <> () [] {} <> () [] {} <> () [] {} <>
+I:(2)o&p&e&n&(&g&a&r&)&t&h&c - clockwork_citadel-49-2
+D:open (gear) then close [vault] with {care}
+I:(3)t&h&e&<&g&a&r&>&c&p&s&l - clockwork_citadel-49-3
+D:the <gearheart> accepts clean paired keys
+I:(4)m&a&t&c&h&e&v&r&y&b&k&f - clockwork_citadel-49-4
+D:match every bracket before the engine wakes.
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_50
+B:KeyQuest - Day 50 - Starfall Library: Math Signs
+T:Introduce simple operator signs.
+ :Arc: Starfall Library. symbols, operators, and code-like flow.
+ :Focus: symbols, operators, and code-like flow, math signs.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)1&+&2&=&3 - starfall_library-50-1
+D:1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3
+I:(2)4&-&1&=&3 - starfall_library-50-2
+D:4 - 1 = 3 4 - 1 = 3 4 - 1 = 3 4 - 1 = 3 4 - 1 = 3 4 - 1 = 3
+I:(3)l&i&g&h&t&+&f&o&c&u&s&= - starfall_library-50-3
+D:light + focus = clear typing
+
+G:STARFALL_LIBRARY
+
+*:DAY_51
+B:KeyQuest - Day 51 - Starfall Library: Slash And Star
+T:Practice slash and star symbols.
+ :Arc: Starfall Library. symbols, operators, and code-like flow.
+ :Focus: symbols, operators, and code-like flow, slash and star.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)/&* - starfall_library-51-1
+D:/ * / * / * / * / * / * / * / * / * / * / * / * / * / * / * / *
+I:(2)p&a&t&h&/&m&s&r&*&k&e&y - starfall_library-51-2
+D:path / map star * key path / map star * key path / map star * key
+I:(3)r&e&a&d&/&s&l&o&w&y&n&m - starfall_library-51-3
+D:read / slowly and mark * carefully
+
+G:STARFALL_LIBRARY
+
+*:DAY_52
+B:KeyQuest - Day 52 - Starfall Library: Quotes
+T:Use quotes around short words.
+ :Arc: Starfall Library. symbols, operators, and code-like flow.
+ :Focus: symbols, operators, and code-like flow, quotes.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)"&k&e&y&m&a&p - starfall_library-52-1
+D:"key" "map" "key" "map" "key" "map" "key" "map" "key" "map"
+I:(2)'&g&o&r&e&s&t - starfall_library-52-2
+D:'go' 'rest' 'go' 'rest' 'go' 'rest' 'go' 'rest' 'go' 'rest'
+I:(3)t&h&e&s&i&g&n&a&y&"&o&l - starfall_library-52-3
+D:the sign says "hold steady" before moving
+
+G:STARFALL_LIBRARY
+
+*:DAY_53
+B:KeyQuest - Day 53 - Starfall Library: Colon Signals
+T:Practice colon and semicolon notes.
+ :Arc: Starfall Library. symbols, operators, and code-like flow.
+ :Focus: symbols, operators, and code-like flow, colon signals.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)k&e&y&:&g&a&t&;&m&p&h - starfall_library-53-1
+D:key: gate; map: path; key: gate; map: path; key: gate; map: path;
+I:(2)n&o&t&e&:&b&r&a&h&;&y&p - starfall_library-53-2
+D:note: breathe; type: slowly; check: accuracy;
+I:(3)s&i&g&n&a&l&:&c&e&r&;&h - starfall_library-53-3
+D:signal: clear; hands: calm; route: open;
+
+G:STARFALL_LIBRARY
+
+*:DAY_54
+B:KeyQuest - Day 54 - Starfall Library: Code Words
+T:Combine symbols with code-like English.
+ :Arc: Starfall Library. symbols, operators, and code-like flow.
+ :Focus: symbols, operators, and code-like flow, code words.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)i&f&g&a&t&e&=&o&p&n&h&y - starfall_library-54-1
+D:if gate = open then type calm words
+I:(2)c&o&u&n&t&+&f&s&-&p&a&i - starfall_library-54-2
+D:count + focus - panic = steady hands
+I:(3)p&a&t&h&/&r&o&m&k&e&y&s - starfall_library-54-3
+D:path / room / key keeps the record clear
+
+G:STARFALL_LIBRARY
+
+*:DAY_55
+B:KeyQuest - Day 55 - Starfall Library: Archive Review
+T:Review operators and punctuation.
+ :Arc: Starfall Library. symbols, operators, and code-like flow.
+ :Focus: symbols, operators, and code-like flow, archive review.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)1&+&2&=&3&;&4&- - starfall_library-55-1
+D:1 + 2 = 3; 4 - 1 = 3; 1 + 2 = 3; 4 - 1 = 3; 1 + 2 = 3; 4 - 1 = 3;
+I:(2)r&e&c&o&d&:&"&s&t&a&y&; - starfall_library-55-2
+D:record: "steady"; status: "clear";
+I:(3)t&h&e&a&r&c&i&v&o&p&n&s - starfall_library-55-3
+D:the archive opens when symbols stay in order
+
+G:STARFALL_LIBRARY
+
+*:DAY_56
+B:KeyQuest - Day 56 - Starfall Library: Archivist Trial
+T:Clear the Archivist Trial with symbol flow.
+ :Arc: Starfall Library. symbols, operators, and code-like flow.
+ :Focus: symbols, operators, and code-like flow, archivist trial.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)k&e&y&+&m&a&p&=&t&h&;&c - starfall_library-56-1
+D:key + map = path; path + calm = progress;
+I:(2)r&e&a&d&"&s&i&g&n&l&/&m - starfall_library-56-2
+D:read "signal" / mark "gate" / hold focus
+I:(3)i&f&r&o&m&=&c&l&e&a&t&h - starfall_library-56-3
+D:if room = clear then move slowly.
+I:(4)t&h&e&a&r&c&i&v&s&u&y&m - starfall_library-56-4
+D:the archivist trusts accurate symbols.
+
+G:STARFALL_LIBRARY
+
+*:DAY_57
+B:KeyQuest - Day 57 - Dragon Spine: Pressure Warmup
+T:Begin pressure practice with clean resets.
+ :Arc: Dragon Spine. accuracy under speed pressure.
+ :Focus: accuracy under speed pressure, pressure warmup.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)h&o&l&d&c&a&m&t&y&p&e&r - dragon_spine-57-1
+D:hold calm type true hold calm type true hold calm type true
+I:(2)t&h&e&r&i&d&g&s&b&u&a&n - dragon_spine-57-2
+D:the ridge is high but the hands stay low
+I:(3)a&c&u&r&y&i&s&t&h&e&l&d - dragon_spine-57-3
+D:accuracy is the shield before speed.
+
+G:DRAGON_SPINE
+
+*:DAY_58
+B:KeyQuest - Day 58 - Dragon Spine: Longer Climb
+T:Climb through longer phrases.
+ :Arc: Dragon Spine. accuracy under speed pressure.
+ :Focus: accuracy under speed pressure, longer climb.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)t&h&e&d&r&a&g&o&n&i&s&b - dragon_spine-58-1
+D:the dragon road rises beyond the quiet stone gate
+I:(2)e&a&c&h&r&f&u&l&w&o&d&k - dragon_spine-58-2
+D:each careful word keeps the traveler on the ridge
+I:(3)f&i&n&s&h&t&e&l&a&c&y&b - dragon_spine-58-3
+D:finish the line as cleanly as it began
+
+G:DRAGON_SPINE
+
+*:DAY_59
+B:KeyQuest - Day 59 - Dragon Spine: Heat Control
+T:Keep control with capitals and numbers.
+ :Arc: Dragon Spine. accuracy under speed pressure.
+ :Focus: accuracy under speed pressure, heat control.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)G&a&t&e&1&2&o&p&n&s&f&r - dragon_spine-59-1
+D:Gate 12 opens after Signal 34.
+I:(2)D&r&a&g&o&n&7&c&i&l&e&s - dragon_spine-59-2
+D:Dragon 7 circles Tower 9 before dawn.
+I:(3)K&e&p&3&c&a&l&m&b&r&t&h - dragon_spine-59-3
+D:Keep 3 calm breaths before Route 5.
+
+G:DRAGON_SPINE
+
+*:DAY_60
+B:KeyQuest - Day 60 - Dragon Spine: No Panic
+T:Practice recovery after dense punctuation.
+ :Arc: Dragon Spine. accuracy under speed pressure.
+ :Focus: accuracy under speed pressure, no panic.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)b&r&e&a&t&h&,&c&o&n&i&u - dragon_spine-60-1
+D:breathe, correct, continue; do not chase the error.
+I:(2)t&h&e&o&p&a&b&n&d&s&,&u - dragon_spine-60-2
+D:the hot path bends, but steady fingers recover.
+I:(3)s&l&o&w&c&r&e&t&i&n&b&a - dragon_spine-60-3
+D:slow correction beats fast panic every time.
+
+G:DRAGON_SPINE
+
+*:DAY_61
+B:KeyQuest - Day 61 - Dragon Spine: Focus Run
+T:Hold attention through connected sentences.
+ :Arc: Dragon Spine. accuracy under speed pressure.
+ :Focus: accuracy under speed pressure, focus run.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)T&h&e&b&r&i&g&t&d&n&a&o - dragon_spine-61-1
+D:The bright ridge narrows as the old dragon wakes.
+I:(2)A&c&a&l&m&t&r&v&e&d&s&h - dragon_spine-61-2
+D:A calm traveler reads the wind and keeps moving.
+I:(3)E&v&e&r&y&c&l&a&n&w&o&d - dragon_spine-61-3
+D:Every clean word becomes another safe step.
+
+G:DRAGON_SPINE
+
+*:DAY_62
+B:KeyQuest - Day 62 - Dragon Spine: Wyrm Review
+T:Review pressure with mixed content.
+ :Arc: Dragon Spine. accuracy under speed pressure.
+ :Focus: accuracy under speed pressure, wyrm review.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)R&o&u&t&e&4&2&:&c&l&i&m - dragon_spine-62-1
+D:Route 42: climb, pause, breathe, continue.
+I:(2)T&h&e&r&i&d&g&m&a&k&s&y - dragon_spine-62-2
+D:The ridge marker says "steady hands survive."
+I:(3)f&o&c&u&s&+&p&a&t&i&e&n - dragon_spine-62-3
+D:focus + patience = safe travel under pressure
+
+G:DRAGON_SPINE
+
+*:DAY_63
+B:KeyQuest - Day 63 - Dragon Spine: Wyrm Trial
+T:Clear the Wyrm Trial with accuracy first.
+ :Arc: Dragon Spine. accuracy under speed pressure.
+ :Focus: accuracy under speed pressure, wyrm trial.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)T&h&e&d&r&a&g&o&n&w&t&c - dragon_spine-63-1
+D:The dragon watches each key and every pause.
+I:(2)R&o&u&t&e&6&3&i&s&n&a&r - dragon_spine-63-2
+D:Route 63 is narrow, bright, and unforgiving.
+I:(3)B&r&e&a&t&h&,&y&p&c&o&v - dragon_spine-63-3
+D:Breathe, type, recover; the ridge will not hurry.
+I:(4)T&h&e&w&y&r&m&i&l&d&s&t - dragon_spine-63-4
+D:The wyrm yields to calm accurate hands.
+
+G:DRAGON_SPINE
+
+*:DAY_64
+B:KeyQuest - Day 64 - Moonlit Labyrinth: Slow Repair
+T:Return to slow correction and weak-key awareness.
+ :Arc: Moonlit Labyrinth. weak-key recovery and calm correction.
+ :Focus: weak-key recovery and calm correction, slow repair.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)q&z&p&; - moonlit_labyrinth-64-1
+D:q z p ; q z p ; q z p ; q z p ; q z p ; q z p ; q z p ; q z p ;
+I:(2)v&b&n&m - moonlit_labyrinth-64-2
+D:v b n m v b n m v b n m v b n m v b n m v b n m v b n m v b n m
+I:(3)s&l&o&w&r&e&p&a&i&m&k&t - moonlit_labyrinth-64-3
+D:slow repair makes the lost path visible
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_65
+B:KeyQuest - Day 65 - Moonlit Labyrinth: Outer Keys
+T:Target outer reaches that often become weak.
+ :Arc: Moonlit Labyrinth. weak-key recovery and calm correction.
+ :Focus: weak-key recovery and calm correction, outer keys.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)q&a&;&p - moonlit_labyrinth-65-1
+D:qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p
+I:(2)z&q&p&; - moonlit_labyrinth-65-2
+D:zq p; zq p; zq p; zq p; zq p; zq p; zq p; zq p; zq p; zq p;
+I:(3)q&u&i&e&t&p&a&h&s&b&y&o - moonlit_labyrinth-65-3
+D:quiet paths pass beyond pale pillars
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_66
+B:KeyQuest - Day 66 - Moonlit Labyrinth: Bottom Repair
+T:Repair bottom-row hesitation.
+ :Arc: Moonlit Labyrinth. weak-key recovery and calm correction.
+ :Focus: weak-key recovery and calm correction, bottom repair.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)c&v&n&m&b - moonlit_labyrinth-66-1
+D:cv nm vb cv nm vb cv nm vb cv nm vb cv nm vb cv nm vb cv nm vb
+I:(2)m&o&v&e&b&r&a&n&c&l - moonlit_labyrinth-66-2
+D:move brave never calm move brave never calm move brave never calm
+I:(3)t&h&e&m&a&z&b&n&d&s&l&o - moonlit_labyrinth-66-3
+D:the maze bends below the home row
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_67
+B:KeyQuest - Day 67 - Moonlit Labyrinth: Symbol Repair
+T:Review symbols slowly.
+ :Arc: Moonlit Labyrinth. weak-key recovery and calm correction.
+ :Focus: weak-key recovery and calm correction, symbol repair.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)(&)&[&]&{&} - moonlit_labyrinth-67-1
+D:() [] {} () [] {} () [] {} () [] {} () [] {} () [] {} () [] {}
+I:(2)1&+&2&=&3 - moonlit_labyrinth-67-2
+D:1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3
+I:(3)r&e&p&a&i&[&s&m&l&]&o&b - moonlit_labyrinth-67-3
+D:repair [small] errors before {large} ones
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_68
+B:KeyQuest - Day 68 - Moonlit Labyrinth: Mirror Paths
+T:Use mirrored phrases to expose uneven hands.
+ :Arc: Moonlit Labyrinth. weak-key recovery and calm correction.
+ :Focus: weak-key recovery and calm correction, mirror paths.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)a&s&d&f&j&k&l&; - moonlit_labyrinth-68-1
+D:asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj
+I:(2)q&w&e&r&u&i&o&p - moonlit_labyrinth-68-2
+D:qwer rewq uiop poiu qwer rewq uiop poiu qwer rewq uiop poiu
+I:(3)l&e&f&t&p&a&h&r&i&g&b&o - moonlit_labyrinth-68-3
+D:left path right path both return home
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_69
+B:KeyQuest - Day 69 - Moonlit Labyrinth: Labyrinth Review
+T:Review mixed weak-key prompts.
+ :Arc: Moonlit Labyrinth. weak-key recovery and calm correction.
+ :Focus: weak-key recovery and calm correction, labyrinth review.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)q&u&i&e&t&z&b&r&a&p&h&s - moonlit_labyrinth-69-1
+D:quiet zebra paths puzzle every brave novice
+I:(2)s&y&m&b&o&l&,&n&u&e&r&a - moonlit_labyrinth-69-2
+D:symbols, numbers, and outer keys need patience.
+I:(3)c&o&r&e&t&h&s&m&a&l&i&b - moonlit_labyrinth-69-3
+D:correct the small miss before moving onward
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_70
+B:KeyQuest - Day 70 - Moonlit Labyrinth: Minotaur Trial
+T:Clear the Minotaur Trial by recovering cleanly.
+ :Arc: Moonlit Labyrinth. weak-key recovery and calm correction.
+ :Focus: weak-key recovery and calm correction, minotaur trial.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)q&z&p&;&v&b&n&m - moonlit_labyrinth-70-1
+D:q z p ; v b n m q z p ; v b n m q z p ; v b n m q z p ; v b n m
+I:(2)q&u&i&e&t&s&y&m&b&o&l&[ - moonlit_labyrinth-70-2
+D:quiet symbols [return] after {careful} repair
+I:(3)t&h&e&m&a&z&r&w&d&s&p&i - moonlit_labyrinth-70-3
+D:the maze rewards patience, not panic.
+I:(4)r&e&c&o&v&a&h&k&y&n&d&l - moonlit_labyrinth-70-4
+D:recover each key and leave the labyrinth.
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_71
+B:KeyQuest - Day 71 - Obsidian Throne: Mixed Marks
+T:Introduce denser punctuation.
+ :Arc: Obsidian Throne. mixed punctuation and long-form focus.
+ :Focus: mixed punctuation and long-form focus, mixed marks.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)w&a&i&t&,&l&o&k&;&y&p&e - obsidian_throne-71-1
+D:wait, look; type: slowly.
+I:(2)k&e&y&:&f&o&u&n&d&,&g&a - obsidian_throne-71-2
+D:key: found, gate: open, path: clear.
+I:(3)t&h&e&r&o&n&i&s&d&a&k&; - obsidian_throne-71-3
+D:the throne is dark; the signal is bright.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_72
+B:KeyQuest - Day 72 - Obsidian Throne: Quote Orders
+T:Practice quoted commands.
+ :Arc: Obsidian Throne. mixed punctuation and long-form focus.
+ :Focus: mixed punctuation and long-form focus, quote orders.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)T&h&e&g&u&a&r&d&s&y&,&" - obsidian_throne-72-1
+D:The guard says, "hold the line."
+I:(2)T&h&e&m&a&p&r&d&s&,&"&t - obsidian_throne-72-2
+D:The map reads, "turn left, then pause."
+I:(3)S&h&e&w&i&s&p&r&,&"&a&c - obsidian_throne-72-3
+D:She whispers, "accuracy breaks the seal."
+
+G:OBSIDIAN_THRONE
+
+*:DAY_73
+B:KeyQuest - Day 73 - Obsidian Throne: Long Focus
+T:Hold focus through punctuation-rich phrases.
+ :Arc: Obsidian Throne. mixed punctuation and long-form focus.
+ :Focus: mixed punctuation and long-form focus, long focus.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)B&e&y&o&n&d&t&h&b&l&a&c - obsidian_throne-73-1
+D:Beyond the black hall, every comma becomes a breath.
+I:(2)T&h&e&o&l&d&c&r&w&n&a&i - obsidian_throne-73-2
+D:The old crown waits; calm hands answer without fear.
+I:(3)A&l&o&n&g&i&e&s&y&v&r&a - obsidian_throne-73-3
+D:A long line is only several small clean choices.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_74
+B:KeyQuest - Day 74 - Obsidian Throne: Clause Chains
+T:Practice clauses joined by punctuation.
+ :Arc: Obsidian Throne. mixed punctuation and long-form focus.
+ :Focus: mixed punctuation and long-form focus, clause chains.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)l&o&k&a&h&e&d&;&b&r&t&n - obsidian_throne-74-1
+D:look ahead; breathe once; type the next word.
+I:(2)t&h&e&a&l&n&r&o&w&s&;&c - obsidian_throne-74-2
+D:the hall narrows; the torch dims; focus remains.
+I:(3)s&l&o&w&h&a&n&d&i&;&r&u - obsidian_throne-74-3
+D:slow hands win; rushed hands repeat the lesson.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_75
+B:KeyQuest - Day 75 - Obsidian Throne: Dense Review
+T:Review punctuation, capitals, and numbers.
+ :Arc: Obsidian Throne. mixed punctuation and long-form focus.
+ :Focus: mixed punctuation and long-form focus, dense review.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)R&o&m&7&5&:&"&s&t&e&a&d - obsidian_throne-75-1
+D:Room 75: "steady," says the silent crown.
+I:(2)G&a&t&e&3&o&p&n&s&;&4&w - obsidian_throne-75-2
+D:Gate 3 opens; Gate 4 waits; Gate 5 listens.
+I:(3)c&l&e&a&r&m&k&s&,&n&w&o - obsidian_throne-75-3
+D:clear marks, clean words, and calm recovery.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_76
+B:KeyQuest - Day 76 - Obsidian Throne: Crown Approach
+T:Prepare for the crown trial.
+ :Arc: Obsidian Throne. mixed punctuation and long-form focus.
+ :Focus: mixed punctuation and long-form focus, crown approach.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)T&h&e&o&b&s&i&d&a&n&t&p - obsidian_throne-76-1
+D:The obsidian steps rise slowly toward the throne.
+I:(2)E&a&c&h&m&r&k&t&e&s&:&o - obsidian_throne-76-2
+D:Each mark matters: comma, period, colon, quote.
+I:(3)D&o&n&t&r&u&s&h&e&f&i&a - obsidian_throne-76-3
+D:Do not rush the final line before the crown.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_77
+B:KeyQuest - Day 77 - Obsidian Throne: Crown Trial
+T:Clear the Crown Trial with long-form focus.
+ :Arc: Obsidian Throne. mixed punctuation and long-form focus.
+ :Focus: mixed punctuation and long-form focus, crown trial.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)T&h&e&c&r&o&w&n&s&a&y&, - obsidian_throne-77-1
+D:The crown says, "type clearly, then continue."
+I:(2)R&o&m&7&:&p&a&u&s&e&,&b - obsidian_throne-77-2
+D:Room 77: pause, breathe, correct, proceed.
+I:(3)L&o&n&g&f&c&u&s&t&r&d&a - obsidian_throne-77-3
+D:Long focus turns dark punctuation into light.
+I:(4)T&h&e&t&r&o&n&p&s&f&a&d - obsidian_throne-77-4
+D:The throne opens for steady accurate hands.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_78
+B:KeyQuest - Day 78 - Dawn Citadel: Full Keyboard Scan
+T:Review the full keyboard in organized bands.
+ :Arc: Dawn Citadel. full-keyboard mastery review.
+ :Focus: full-keyboard mastery review, full keyboard scan.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)q&w&e&r&a&s&d&f&z&x&c&v - dawn_citadel-78-1
+D:qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv
+I:(2)u&i&o&p&j&k&l&;&n&m&,&. - dawn_citadel-78-2
+D:uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,.
+I:(3)1&2&3&4&5&6&7&8&9&0 - dawn_citadel-78-3
+D:1234 567 890 1234 567 890 1234 567 890 1234 567 890 1234 567 890
+
+G:DAWN_CITADEL
+
+*:DAY_79
+B:KeyQuest - Day 79 - Dawn Citadel: Capital Review
+T:Review capitals in full-keyboard phrases.
+ :Arc: Dawn Citadel. full-keyboard mastery review.
+ :Focus: full-keyboard mastery review, capital review.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)D&a&w&n&C&i&t&d&e&l&o&p - dawn_citadel-79-1
+D:Dawn Citadel opens Gate 79 with calm hands.
+I:(2)M&i&r&a&n&d&O&w&e&c&y&K - dawn_citadel-79-2
+D:Mira and Owen carry Key 12 to Tower 34.
+I:(3)E&v&e&r&y&C&a&p&i&t&l&L - dawn_citadel-79-3
+D:Every Capital Letter returns to home.
+
+G:DAWN_CITADEL
+
+*:DAY_80
+B:KeyQuest - Day 80 - Dawn Citadel: Symbol Review
+T:Review symbols and brackets.
+ :Arc: Dawn Citadel. full-keyboard mastery review.
+ :Focus: full-keyboard mastery review, symbol review.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)(&)&[&]&{&}&<&> - dawn_citadel-80-1
+D:() [] {} <> () [] {} <> () [] {} <> () [] {} <> () [] {} <>
+I:(2)1&+&2&=&3&; - dawn_citadel-80-2
+D:1 + 2 = 3; 1 + 2 = 3; 1 + 2 = 3; 1 + 2 = 3; 1 + 2 = 3; 1 + 2 = 3;
+I:(3)r&e&c&o&d&[&a&w&n&]&=&{ - dawn_citadel-80-3
+D:record [dawn] = {clear} + "focus"
+
+G:DAWN_CITADEL
+
+*:DAY_81
+B:KeyQuest - Day 81 - Dawn Citadel: Phrase Review
+T:Type longer phrases with previous skills.
+ :Arc: Dawn Citadel. full-keyboard mastery review.
+ :Focus: full-keyboard mastery review, phrase review.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)t&h&e&d&a&w&n&c&i&l&g&r - dawn_citadel-81-1
+D:the dawn citadel gathers every lesson into one path
+I:(2)s&t&e&a&d&y&r&h&m&c&i&l - dawn_citadel-81-2
+D:steady rhythm carries letters, numbers, and marks
+I:(3)f&u&l&m&a&s&t&e&r&y&b&g - dawn_citadel-81-3
+D:full mastery begins with one clean line at a time
+
+G:DAWN_CITADEL
+
+*:DAY_82
+B:KeyQuest - Day 82 - Dawn Citadel: Recovery Review
+T:Return to hard keys and correct them calmly.
+ :Arc: Dawn Citadel. full-keyboard mastery review.
+ :Focus: full-keyboard mastery review, recovery review.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)q&z&p&;&v&b&n&m - dawn_citadel-82-1
+D:q z p ; v b n m q z p ; v b n m q z p ; v b n m q z p ; v b n m
+I:(2)r&e&c&o&v&[&q&u&i&t&l&y - dawn_citadel-82-2
+D:recover [quietly] after {difficult} symbols
+I:(3)t&h&e&c&i&a&d&l&r&w&s&m - dawn_citadel-82-3
+D:the citadel rewards calm correction
+
+G:DAWN_CITADEL
+
+*:DAY_83
+B:KeyQuest - Day 83 - Dawn Citadel: Final Review
+T:Mix rows, capitals, numbers, and punctuation.
+ :Arc: Dawn Citadel. full-keyboard mastery review.
+ :Focus: full-keyboard mastery review, final review.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)G&a&t&e&8&3&o&p&n&s&w&h - dawn_citadel-83-1
+D:Gate 83 opens when "focus" stays bright.
+I:(2)D&a&w&n&l&i&g&h&t&c&r&o - dawn_citadel-83-2
+D:Dawn light crosses room 12, hall 34, and tower 56.
+I:(3)t&y&p&e&s&l&o&w&n&u&g&h - dawn_citadel-83-3
+D:type slowly enough to finish cleanly
+
+G:DAWN_CITADEL
+
+*:DAY_84
+B:KeyQuest - Day 84 - Dawn Citadel: Dawn Trial
+T:Clear the Dawn Trial as a mastery review.
+ :Arc: Dawn Citadel. full-keyboard mastery review.
+ :Focus: full-keyboard mastery review, dawn trial.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)q&w&e&r&a&s&d&f&z&x&c&v - dawn_citadel-84-1
+D:qwer asdf zxcv uiop qwer asdf zxcv uiop qwer asdf zxcv uiop
+I:(2)D&a&w&n&C&i&t&d&e&l&:&[ - dawn_citadel-84-2
+D:Dawn Citadel: [ready] = {calm} + "accuracy"
+I:(3)E&v&e&r&y&o&w&,&n&u&m&b - dawn_citadel-84-3
+D:Every row, number, and mark returns home.
+I:(4)T&h&e&f&i&n&a&l&g&t&p&r - dawn_citadel-84-4
+D:The final gate appears in the morning light.
+
+G:DAWN_CITADEL
+
+*:DAY_85
+B:KeyQuest - Day 85 - Final Gate: First Seal
+T:Begin the final integrated quest.
+ :Arc: Final Gate. final integrated typing quest.
+ :Focus: final integrated typing quest, first seal.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)a&s&d&f&q&w&e&r&z&x&c&v - final_gate-85-1
+D:asdf qwer zxcv 1234 asdf qwer zxcv 1234 asdf qwer zxcv 1234
+I:(2)T&h&e&f&i&r&s&t&a&l&o&p - final_gate-85-2
+D:The first seal opens for calm accurate hands.
+I:(3)R&e&v&i&w&r&y&o&b&f&t&h - final_gate-85-3
+D:Review every row before the final spell begins.
+I:(4)s&t&e&a&d&y&f&o&c&u&r&i - final_gate-85-4
+D:steady focus carries the key toward silence
+
+G:FINAL_GATE
+
+*:DAY_86
+B:KeyQuest - Day 86 - Final Gate: Second Seal
+T:Mix capitals, numbers, and punctuation.
+ :Arc: Final Gate. final integrated typing quest.
+ :Focus: final integrated typing quest, second seal.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)S&e&a&l&2&:&"&H&o&d&f&c - final_gate-86-1
+D:Seal 2: "Hold focus," says the old gate.
+I:(2)K&e&y&8&6&t&u&r&n&s&l&o - final_gate-86-2
+D:Key 86 turns slowly; the path remains clear.
+I:(3)A&B&r&i&g&h&t&H&a&n&d&y - final_gate-86-3
+D:A Bright Hand types 3 clean lines before dawn.
+I:(4)n&u&m&b&e&r&s&a&d&k&o&y - final_gate-86-4
+D:numbers and marks obey patient fingers
+
+G:FINAL_GATE
+
+*:DAY_87
+B:KeyQuest - Day 87 - Final Gate: Third Seal
+T:Use code-like patterns inside final text.
+ :Arc: Final Gate. final integrated typing quest.
+ :Focus: final integrated typing quest, third seal.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)i&f&g&a&t&e&=&o&p&n&h&l - final_gate-87-1
+D:if gate = open then hold steady focus
+I:(2)f&i&n&a&l&[&s&e&]&=&{&c - final_gate-87-2
+D:final[seal] = {calm} + "accuracy"
+I:(3)p&a&t&h&/&k&e&y&l&i&g&d - final_gate-87-3
+D:path / key / light leads beyond silence
+I:(4)p&a&i&r&e&d&s&y&m&b&o&l - final_gate-87-4
+D:paired symbols guard the third seal
+
+G:FINAL_GATE
+
+*:DAY_88
+B:KeyQuest - Day 88 - Final Gate: Fourth Seal
+T:Hold long-form focus through final sentences.
+ :Arc: Final Gate. final integrated typing quest.
+ :Focus: final integrated typing quest, fourth seal.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)T&h&e&L&o&r&d&f&S&i&l&n - final_gate-88-1
+D:The Lord of Silence waits beyond the final gate.
+I:(2)E&v&e&r&y&l&s&o&n&t&u&a - final_gate-88-2
+D:Every lesson returns as one quiet line of light.
+I:(3)D&o&n&t&r&u&s&h&e&d&i&g - final_gate-88-3
+D:Do not rush the ending; complete it cleanly.
+I:(4)a&c&u&r&y&t&n&s&h&e&l&d - final_gate-88-4
+D:accuracy turns the last shadow into dawn
+
+G:FINAL_GATE
+
+*:DAY_89
+B:KeyQuest - Day 89 - Final Gate: Last Camp
+T:Review the full journey before the final trial.
+ :Arc: Final Gate. final integrated typing quest.
+ :Focus: final integrated typing quest, last camp.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)N&o&v&i&c&e&h&a&n&d&s&b - final_gate-89-1
+D:Novice hands became steady hands over many days.
+I:(2)R&o&w&s&,&n&u&m&b&e&r&y - final_gate-89-2
+D:Rows, numbers, symbols, and stories gather here.
+I:(3)B&r&e&a&t&h&o&n&c&b&f&i - final_gate-89-3
+D:Breathe once before the final spell is typed.
+I:(4)t&h&e&l&a&s&c&m&p&i&q&u - final_gate-89-4
+D:the last camp is quiet, bright, and ready
+
+G:FINAL_GATE
+
+*:DAY_90
+B:KeyQuest - Day 90 - Final Gate: Last Spell Trial
+T:Complete the final integrated typing quest.
+ :Arc: Final Gate. final integrated typing quest.
+ :Focus: final integrated typing quest, last spell trial.
+ :Type with accuracy first; let speed appear only after the line is clean.
+I:(1)T&h&e&f&i&n&a&l&g&t&o&p - final_gate-90-1
+D:The final gate opens when every key returns home.
+I:(2)K&e&y&Q&u&s&t&D&a&9&0&: - final_gate-90-2
+D:KeyQuest Day 90: "Accuracy breaks the silence."
+I:(3)i&f&o&c&u&s&=&t&e&a&d&y - final_gate-90-3
+D:if focus = steady then the last spell shines
+I:(4)T&h&e&L&o&r&d&f&S&i&l&n - final_gate-90-4
+D:The Lord of Silence falls to calm typing.
+
+G:FINAL_GATE
+
 *:ABOUT
 B:About KeyQuest Typing Journey
-T:This GNU Typist script adapts the first 28 implemented KeyQuest lessons.
- :The original game uses JSON lessons, RPG progression, rewards, and story
- :scenes. This port keeps the English typing prompts and turns the journey
- :into simple terminal drills for gtypist.
- :Use one day at a time, repeat lessons when accuracy drops, and value calm
- :finger placement over speed.
+T:This GNU Typist script adapts KeyQuest into a full 90-day typing
+ :journey. Days 1-28 preserve the implemented KeyQuest lesson prompts;
+ :Days 29-90 extend the journey for gtypist using the official quest map
+ :arc themes.
+ :Use one day at a time, repeat lessons when accuracy drops, and value
+ :calm finger placement over speed.
 G:MENU
 
 *:EXIT
 B:Thank you for training with KeyQuest.
-T:Practice a little every day. Accuracy opens the next gate.
+T:Practice a little every day. Accuracy opens the final gate.
 X:


### PR DESCRIPTION
## Summary
- Expand `keyquest.typ` from 28 days to a full 90-day KeyQuest typing journey.
- Add Day 29-90 arc menus and gtypist-native drills based on KeyQuest quest-map themes.
- Update README and the curriculum manual to describe the full journey and source split.

## Test plan
- Statically checked `keyquest.typ` label, menu, `G:`, day coverage, and line-length constraints.
- Ran linter diagnostics for `README.md`, `docs/keyquest-curriculum.md`, and `keyquest.typ`.
- Smoke-checked `gtypist -q -S -l ABOUT keyquest.typ`, `DAY_42`, and `DAY_90` with a timeout because gtypist is interactive.

Closes #4.

Made with [Cursor](https://cursor.com)