### PR TITLE
Add localized KeyQuest gtypist narration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains two terminal lesson scripts:
 
 - `xion.typ`: the original weak-finger etude collection.
 - `keyquest.typ`: a 90-day GNU Typist typing journey adapted from KeyQuest.
+- `keyquest.ja.typ`, `keyquest.es.typ`, `keyquest.fr.typ`, `keyquest.de.typ`: localized KeyQuest narration with the same typing drills.
 
 ## Requirements
 
@@ -29,6 +30,15 @@ Run the KeyQuest journey directly from this repository:
 
 ```sh
 gtypist keyquest.typ
+```
+
+Run a localized KeyQuest narration file:
+
+```sh
+gtypist keyquest.ja.typ
+gtypist keyquest.es.typ
+gtypist keyquest.fr.typ
+gtypist keyquest.de.typ
 ```
 
 Run the original weak-finger etudes:
@@ -58,6 +68,7 @@ gtypist keyquest.typ
 - Days 1-28 preserve the implemented KeyQuest lesson prompts and reshape them for gtypist drills.
 - Days 29-90 are gtypist-native extensions based on KeyQuest's official quest map themes.
 - The journey covers 12 weekly arcs plus a 6-day finale, from home position through full-keyboard mastery.
+- Localized files translate menus, banners, and guidance only; every `D:` typing line stays identical across languages.
 
 The original KeyQuest game presents lessons through RPG progression, story scenes, scoring, and rewards. GNU Typist is a simpler terminal trainer, so this port keeps the typing substance and reshapes the experience into menus, concise training notes, and drill lines.
 

--- a/docs/keyquest-curriculum.md
+++ b/docs/keyquest-curriculum.md
@@ -12,12 +12,23 @@ gtypist keyquest.typ
 
 Choose an arc from the main menu, then choose a day. The lesson returns to its arc menu when complete.
 
+Localized narration files are also available:
+
+```sh
+gtypist keyquest.ja.typ
+gtypist keyquest.es.typ
+gtypist keyquest.fr.typ
+gtypist keyquest.de.typ
+```
+
 ## Adaptation Rules
 
 - Each day becomes one GNU Typist lesson block.
 - Typing prompts remain English.
 - Very short prompts are repeated on a drill line so gtypist practice is not too brief.
 - Day 29-90 key groups are derived from their gtypist drill text.
+- Localized `.typ` files translate menus, banners, guidance, and drill labels only.
+- Every localized file keeps the same `D:` typing lines as `keyquest.typ`.
 - RPG systems such as XP, HP, MP, inventory, story gates, and achievements are not simulated in gtypist.
 - Story flavor is kept as concise training framing so the screen stays calm while typing.
 
@@ -191,6 +202,10 @@ A 6-day final integrated quest ending with the Last Spell Trial.
 ## File Map
 
 - `keyquest.typ`: GNU Typist script for the full 90-day KeyQuest journey.
+- `keyquest.ja.typ`: Japanese narration with shared English typing drills.
+- `keyquest.es.typ`: Spanish narration with shared English typing drills.
+- `keyquest.fr.typ`: French narration with shared English typing drills.
+- `keyquest.de.typ`: German narration with shared English typing drills.
 - `xion.typ`: original weak-finger etude script, kept unchanged.
 - `README.md`: installation and quick usage guide.
 - `docs/keyquest-curriculum.md`: this curriculum manual.

--- a/keyquest.de.typ
+++ b/keyquest.de.typ
@@ -1,0 +1,1588 @@
+*:MENU
+M: "KeyQuest Tippabenteuer"
+ :NOVICE_HALL  "Novice Hall"
+ :MEADOW_ROAD  "Meadow Road"
+ :RIVER_GATE  "River Gate"
+ :LANTERN_KEEP  "Lantern Keep"
+ :ASHEN_FORGE  "Ashen Forge"
+ :WINDSPIRE  "Windspire"
+ :CLOCKWORK_CITADEL  "Clockwork Citadel"
+ :STARFALL_LIBRARY  "Starfall Library"
+ :DRAGON_SPINE  "Dragon Spine"
+ :MOONLIT_LABYRINTH  "Moonlit Labyrinth"
+ :OBSIDIAN_THRONE  "Obsidian Throne"
+ :DAWN_CITADEL  "Dawn Citadel"
+ :FINAL_GATE  "Final Gate"
+ :ABOUT  "Uber dieses Skript"
+ :EXIT  "Beenden"
+
+*:NOVICE_HALL
+M: "Novice Hall"
+ :DAY_01  "Tag 01: Home Position"
+ :DAY_02  "Tag 02: Left And Right Balance"
+ :DAY_03  "Tag 03: Finger Responsibility"
+ :DAY_04  "Tag 04: Rhythm Hall"
+ :DAY_05  "Tag 05: First Words"
+ :DAY_06  "Tag 06: Repair The Stance"
+ :DAY_07  "Tag 07: Gatekeeper Trial"
+ :MENU  "Zuruck zum Bogenmenu"
+
+*:MEADOW_ROAD
+M: "Meadow Road"
+ :DAY_08  "Tag 08: First Steps Beyond Home"
+ :DAY_09  "Tag 09: Ring Finger Reach"
+ :DAY_10  "Tag 10: Index Reach"
+ :DAY_11  "Tag 11: Outer Watch"
+ :DAY_12  "Tag 12: Top Row Trail"
+ :DAY_13  "Tag 13: First Flow"
+ :DAY_14  "Tag 14: Waystone Trial"
+ :MENU  "Zuruck zum Bogenmenu"
+
+*:RIVER_GATE
+M: "River Gate"
+ :DAY_15  "Tag 15: Lower Step"
+ :DAY_16  "Tag 16: Valley Reach"
+ :DAY_17  "Tag 17: Bridge Keys"
+ :DAY_18  "Tag 18: Comma And Period"
+ :DAY_19  "Tag 19: Bottom Row Words"
+ :DAY_20  "Tag 20: Current Review"
+ :DAY_21  "Tag 21: Ferryman Trial"
+ :MENU  "Zuruck zum Bogenmenu"
+
+*:LANTERN_KEEP
+M: "Lantern Keep"
+ :DAY_22  "Tag 22: Left Number Row"
+ :DAY_23  "Tag 23: Right Number Row"
+ :DAY_24  "Tag 24: Center Span"
+ :DAY_25  "Tag 25: Counts And Codes"
+ :DAY_26  "Tag 26: Map Marks"
+ :DAY_27  "Tag 27: Mixed Signals"
+ :DAY_28  "Tag 28: Beacon Trial"
+ :MENU  "Zuruck zum Bogenmenu"
+
+*:ASHEN_FORGE
+M: "Ashen Forge"
+ :DAY_29  "Tag 29: Left Shift Spark"
+ :DAY_30  "Tag 30: Right Shift Spark"
+ :DAY_31  "Tag 31: Capital Names"
+ :DAY_32  "Tag 32: Sentence Starts"
+ :DAY_33  "Tag 33: Title Case"
+ :DAY_34  "Tag 34: Shift Review"
+ :DAY_35  "Tag 35: Anvil Trial"
+ :MENU  "Zuruck zum Bogenmenu"
+
+*:WINDSPIRE
+M: "Windspire"
+ :DAY_36  "Tag 36: Even Steps"
+ :DAY_37  "Tag 37: Short Bursts"
+ :DAY_38  "Tag 38: Long Cadence"
+ :DAY_39  "Tag 39: Alternate Pace"
+ :DAY_40  "Tag 40: Breath Marks"
+ :DAY_41  "Tag 41: Gale Review"
+ :DAY_42  "Tag 42: Gale Trial"
+ :MENU  "Zuruck zum Bogenmenu"
+
+*:CLOCKWORK_CITADEL
+M: "Clockwork Citadel"
+ :DAY_43  "Tag 43: Parentheses"
+ :DAY_44  "Tag 44: Brackets"
+ :DAY_45  "Tag 45: Braces"
+ :DAY_46  "Tag 46: Angle Gates"
+ :DAY_47  "Tag 47: Nested Pairs"
+ :DAY_48  "Tag 48: Gear Review"
+ :DAY_49  "Tag 49: Gearheart Trial"
+ :MENU  "Zuruck zum Bogenmenu"
+
+*:STARFALL_LIBRARY
+M: "Starfall Library"
+ :DAY_50  "Tag 50: Math Signs"
+ :DAY_51  "Tag 51: Slash And Star"
+ :DAY_52  "Tag 52: Quotes"
+ :DAY_53  "Tag 53: Colon Signals"
+ :DAY_54  "Tag 54: Code Words"
+ :DAY_55  "Tag 55: Archive Review"
+ :DAY_56  "Tag 56: Archivist Trial"
+ :MENU  "Zuruck zum Bogenmenu"
+
+*:DRAGON_SPINE
+M: "Dragon Spine"
+ :DAY_57  "Tag 57: Pressure Warmup"
+ :DAY_58  "Tag 58: Longer Climb"
+ :DAY_59  "Tag 59: Heat Control"
+ :DAY_60  "Tag 60: No Panic"
+ :DAY_61  "Tag 61: Focus Run"
+ :DAY_62  "Tag 62: Wyrm Review"
+ :DAY_63  "Tag 63: Wyrm Trial"
+ :MENU  "Zuruck zum Bogenmenu"
+
+*:MOONLIT_LABYRINTH
+M: "Moonlit Labyrinth"
+ :DAY_64  "Tag 64: Slow Repair"
+ :DAY_65  "Tag 65: Outer Keys"
+ :DAY_66  "Tag 66: Bottom Repair"
+ :DAY_67  "Tag 67: Symbol Repair"
+ :DAY_68  "Tag 68: Mirror Paths"
+ :DAY_69  "Tag 69: Labyrinth Review"
+ :DAY_70  "Tag 70: Minotaur Trial"
+ :MENU  "Zuruck zum Bogenmenu"
+
+*:OBSIDIAN_THRONE
+M: "Obsidian Throne"
+ :DAY_71  "Tag 71: Mixed Marks"
+ :DAY_72  "Tag 72: Quote Orders"
+ :DAY_73  "Tag 73: Long Focus"
+ :DAY_74  "Tag 74: Clause Chains"
+ :DAY_75  "Tag 75: Dense Review"
+ :DAY_76  "Tag 76: Crown Approach"
+ :DAY_77  "Tag 77: Crown Trial"
+ :MENU  "Zuruck zum Bogenmenu"
+
+*:DAWN_CITADEL
+M: "Dawn Citadel"
+ :DAY_78  "Tag 78: Full Keyboard Scan"
+ :DAY_79  "Tag 79: Capital Review"
+ :DAY_80  "Tag 80: Symbol Review"
+ :DAY_81  "Tag 81: Phrase Review"
+ :DAY_82  "Tag 82: Recovery Review"
+ :DAY_83  "Tag 83: Final Review"
+ :DAY_84  "Tag 84: Dawn Trial"
+ :MENU  "Zuruck zum Bogenmenu"
+
+*:FINAL_GATE
+M: "Final Gate"
+ :DAY_85  "Tag 85: First Seal"
+ :DAY_86  "Tag 86: Second Seal"
+ :DAY_87  "Tag 87: Third Seal"
+ :DAY_88  "Tag 88: Fourth Seal"
+ :DAY_89  "Tag 89: Last Camp"
+ :DAY_90  "Tag 90: Last Spell Trial"
+ :MENU  "Zuruck zum Bogenmenu"
+
+*:DAY_01
+B:KeyQuest - Tag 01 - Novice Hall: Home Position
+T:Tag 01 guidance.
+ :Bogen: Novice Hall. Grundstellung und Fingerverantwortung.
+ :Fokus: Grundstellung und Fingerverantwortung.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)f&j - Ubung 1
+D:f j f j f j f j f j f j f j f j
+I:(2)f&j - Ubung 2
+D:ff jj ff jj ff jj ff jj ff jj ff jj ff jj ff jj
+I:(3)f&j - Ubung 3
+D:fj jf fj jf fj jf fj jf fj jf fj jf fj jf fj jf
+I:(4)a&s&d&f&j&k&l&; - Ubung 4
+D:asdf jkl; asdf jkl; asdf jkl; asdf jkl; asdf jkl; asdf jkl;
+
+G:NOVICE_HALL
+
+*:DAY_02
+B:KeyQuest - Tag 02 - Novice Hall: Left And Right Balance
+T:Tag 02 guidance.
+ :Bogen: Novice Hall. Grundstellung und Fingerverantwortung.
+ :Fokus: Grundstellung und Fingerverantwortung.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)a&s&d&f&j&k&l&; - Ubung 1
+D:asdf jkl; asdf jkl; asdf jkl; asdf jkl; asdf jkl; asdf jkl;
+I:(2)a&s&d&f&j&k&l&; - Ubung 2
+D:asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj
+I:(3)a&f&s&j&d&k&l - Ubung 3
+D:af sj dk fl af sj dk fl af sj dk fl af sj dk fl af sj dk fl
+I:(4)a&s&d&f&j&k&l - Ubung 4
+D:sad lad ask fall sad lad ask fall sad lad ask fall sad lad ask fall
+
+G:NOVICE_HALL
+
+*:DAY_03
+B:KeyQuest - Tag 03 - Novice Hall: Finger Responsibility
+T:Tag 03 guidance.
+ :Bogen: Novice Hall. Grundstellung und Fingerverantwortung.
+ :Fokus: Grundstellung und Fingerverantwortung.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)a&s&d&f&j&k&l&; - Ubung 1
+D:aa ss dd ff jj kk ll ;; aa ss dd ff jj kk ll ;;
+I:(2)a&s&d&f&j&k&l&; - Ubung 2
+D:as df jk l; as df jk l; as df jk l; as df jk l; as df jk l;
+I:(3)a&;&s&l&d&k&f&j - Ubung 3
+D:a; sl dk fj a; sl dk fj a; sl dk fj a; sl dk fj a; sl dk fj
+I:(4)a&s&d&f&j&k&l - Ubung 4
+D:ask sad fall flask ask sad fall flask ask sad fall flask
+
+G:NOVICE_HALL
+
+*:DAY_04
+B:KeyQuest - Tag 04 - Novice Hall: Rhythm Hall
+T:Tag 04 guidance.
+ :Bogen: Novice Hall. Grundstellung und Fingerverantwortung.
+ :Fokus: Grundstellung und Fingerverantwortung.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)a&s&d&f&j&k&l&; - Ubung 1
+D:asdf asdf jkl; jkl; asdf asdf jkl; jkl; asdf asdf jkl; jkl;
+I:(2)f&d&s&a&;&l&k&j - Ubung 2
+D:fdsa fdsa ;lkj ;lkj fdsa fdsa ;lkj ;lkj fdsa fdsa ;lkj ;lkj
+I:(3)a&s&d&f&j&k&l&; - Ubung 3
+D:asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj
+I:(4)a&s&d&f&j&k&l - Ubung 4
+D:ask fall sad flask ask fall sad flask ask fall sad flask
+
+G:NOVICE_HALL
+
+*:DAY_05
+B:KeyQuest - Tag 05 - Novice Hall: First Words
+T:Tag 05 guidance.
+ :Bogen: Novice Hall. Grundstellung und Fingerverantwortung.
+ :Fokus: Grundstellung und Fingerverantwortung.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)a&s&d&l&k - Ubung 1
+D:ask sad lad ask sad lad ask sad lad ask sad lad ask sad lad
+I:(2)f&a&l&s&k - Ubung 2
+D:fall flask fall flask fall flask fall flask fall flask fall flask
+I:(3)d&a&f&s&l - Ubung 3
+D:dad fad salad dad fad salad dad fad salad dad fad salad
+I:(4)a&s&k&l&d&f - Ubung 4
+D:ask lad fall flask ask lad fall flask ask lad fall flask
+
+G:NOVICE_HALL
+
+*:DAY_06
+B:KeyQuest - Tag 06 - Novice Hall: Repair The Stance
+T:Tag 06 guidance.
+ :Bogen: Novice Hall. Grundstellung und Fingerverantwortung.
+ :Fokus: Grundstellung und Fingerverantwortung.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)a&;&s&l - Ubung 1
+D:aa ;; ss ll aa ;; ss ll aa ;; ss ll aa ;; ss ll aa ;; ss ll
+I:(2)a&;&s&l - Ubung 2
+D:a; s; al sl a; s; al sl a; s; al sl a; s; al sl a; s; al sl
+I:(3)s&a&d&l&f - Ubung 3
+D:sad lass fall sad lass fall sad lass fall sad lass fall
+I:(4)a&s&k&l&f&d - Ubung 4
+D:ask lass fall salad ask lass fall salad ask lass fall salad
+
+G:NOVICE_HALL
+
+*:DAY_07
+B:KeyQuest - Tag 07 - Novice Hall: Gatekeeper Trial
+T:Tag 07 guidance.
+ :Bogen: Novice Hall. Grundstellung und Fingerverantwortung.
+ :Fokus: Grundstellung und Fingerverantwortung.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)f&j&a&s&d&k&l&; - Ubung 1
+D:f j as df jk l; f j as df jk l; f j as df jk l; f j as df jk l;
+I:(2)a&s&d&f&j&k&l&; - Ubung 2
+D:asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj
+I:(3)a&s&k&d&l&f - Ubung 3
+D:ask sad lad fall ask sad lad fall ask sad lad fall ask sad lad fall
+I:(4)a&s&k&l&f&d - Ubung 4
+D:ask lass fall salad flask ask lass fall salad flask
+
+G:NOVICE_HALL
+
+*:DAY_08
+B:KeyQuest - Tag 08 - Meadow Road: First Steps Beyond Home
+T:Tag 08 guidance.
+ :Bogen: Meadow Road. Oberreihe erreichen und zur Grundstellung
+ :zuruckkehren.
+ :Fokus: Oberreihe erreichen und zur Grundstellung zuruckkehren.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)f&r&j&u - Ubung 1
+D:fr ju fr ju fr ju fr ju fr ju fr ju fr ju fr ju fr ju fr ju
+I:(2)d&e&k&i - Ubung 2
+D:de ki de ki de ki de ki de ki de ki de ki de ki de ki de ki
+I:(3)r&e&d&k&i - Ubung 3
+D:red kid ride red kid ride red kid ride red kid ride red kid ride
+I:(4)r&u&d&e&i - Ubung 4
+D:rude deer ride rude deer ride rude deer ride rude deer ride
+
+G:MEADOW_ROAD
+
+*:DAY_09
+B:KeyQuest - Tag 09 - Meadow Road: Ring Finger Reach
+T:Tag 09 guidance.
+ :Bogen: Meadow Road. Oberreihe erreichen und zur Grundstellung
+ :zuruckkehren.
+ :Fokus: Oberreihe erreichen und zur Grundstellung zuruckkehren.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)s&w&l&o - Ubung 1
+D:sw lo sw lo sw lo sw lo sw lo sw lo sw lo sw lo sw lo sw lo
+I:(2)w&e&o&l&d - Ubung 2
+D:we old we old we old we old we old we old we old we old
+I:(3)s&l&o&w - Ubung 3
+D:slow low owl slow low owl slow low owl slow low owl slow low owl
+I:(4)o&l&d&w&s - Ubung 4
+D:old owl slow old owl slow old owl slow old owl slow old owl slow
+
+G:MEADOW_ROAD
+
+*:DAY_10
+B:KeyQuest - Tag 10 - Meadow Road: Index Reach
+T:Tag 10 guidance.
+ :Bogen: Meadow Road. Oberreihe erreichen und zur Grundstellung
+ :zuruckkehren.
+ :Fokus: Oberreihe erreichen und zur Grundstellung zuruckkehren.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)f&t&j&y - Ubung 1
+D:ft jy ft jy ft jy ft jy ft jy ft jy ft jy ft jy ft jy ft jy
+I:(2)t&r&y&e - Ubung 2
+D:try yet try yet try yet try yet try yet try yet try yet try yet
+I:(3)d&r&y&t&a - Ubung 3
+D:dry try yard dry try yard dry try yard dry try yard dry try yard
+I:(4)s&t&a&y&r&e&d - Ubung 4
+D:stay ready steady stay ready steady stay ready steady
+
+G:MEADOW_ROAD
+
+*:DAY_11
+B:KeyQuest - Tag 11 - Meadow Road: Outer Watch
+T:Tag 11 guidance.
+ :Bogen: Meadow Road. Oberreihe erreichen und zur Grundstellung
+ :zuruckkehren.
+ :Fokus: Oberreihe erreichen und zur Grundstellung zuruckkehren.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)a&q&;&p - Ubung 1
+D:aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p
+I:(2)q&u&i&c&k&e&t - Ubung 2
+D:quick quiet quick quiet quick quiet quick quiet quick quiet
+I:(3)p&o&i&e&u - Ubung 3
+D:pop pipe pup pop pipe pup pop pipe pup pop pipe pup pop pipe pup
+I:(4)q&u&i&p&c&k&o - Ubung 4
+D:quip quick pop quip quick pop quip quick pop quip quick pop
+
+G:MEADOW_ROAD
+
+*:DAY_12
+B:KeyQuest - Tag 12 - Meadow Road: Top Row Trail
+T:Tag 12 guidance.
+ :Bogen: Meadow Road. Oberreihe erreichen und zur Grundstellung
+ :zuruckkehren.
+ :Fokus: Oberreihe erreichen und zur Grundstellung zuruckkehren.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)q&w&e&r&u&i&o&p - Ubung 1
+D:qwer uiop qwer uiop qwer uiop qwer uiop qwer uiop qwer uiop
+I:(2)t&r&e&w&p&o&i - Ubung 2
+D:trew poi poi trew trew poi poi trew trew poi poi trew
+I:(3)w&e&q&u&i&t&p&o - Ubung 3
+D:we quit we pop we quit we pop we quit we pop we quit we pop
+I:(4)t&y&p&e&u&r&q&i - Ubung 4
+D:type pure quiet type pure quiet type pure quiet type pure quiet
+
+G:MEADOW_ROAD
+
+*:DAY_13
+B:KeyQuest - Tag 13 - Meadow Road: First Flow
+T:Tag 13 guidance.
+ :Bogen: Meadow Road. Oberreihe erreichen und zur Grundstellung
+ :zuruckkehren.
+ :Fokus: Oberreihe erreichen und zur Grundstellung zuruckkehren.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)q&u&i&e&t&r&d - Ubung 1
+D:quiet rider quiet rider quiet rider quiet rider quiet rider
+I:(2)t&y&p&e&o&u&r&s - Ubung 2
+D:type your story type your story type your story type your story
+I:(3)w&e&t&r&y&q&u&i&o&k - Ubung 3
+D:we try quiet work we try quiet work we try quiet work
+I:(4)s&t&e&a&d&y&h&n&p&r&u - Ubung 4
+D:steady hands type true steady hands type true
+
+G:MEADOW_ROAD
+
+*:DAY_14
+B:KeyQuest - Tag 14 - Meadow Road: Waystone Trial
+T:Tag 14 guidance.
+ :Bogen: Meadow Road. Oberreihe erreichen und zur Grundstellung
+ :zuruckkehren.
+ :Fokus: Oberreihe erreichen und zur Grundstellung zuruckkehren.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)q&w&e&r&u&i&o&p&a&s&d&f - Ubung 1
+D:qwer uiop asdf jkl; qwer uiop asdf jkl; qwer uiop asdf jkl;
+I:(2)q&u&i&e&t&y&p&r&w&o&k - Ubung 2
+D:quiet type pure work quiet type pure work quiet type pure work
+I:(3)s&t&e&a&d&y&q&u&i&r - Ubung 3
+D:steady quiet rider steady quiet rider steady quiet rider
+I:(4)y&o&u&r&q&i&e&t&s&a&d&h - Ubung 4
+D:your quiet steady hands type true your quiet steady hands type true
+
+G:MEADOW_ROAD
+
+*:DAY_15
+B:KeyQuest - Tag 15 - River Gate: Lower Step
+T:Tag 15 guidance.
+ :Bogen: River Gate. Unterreihe, Bruckentasten und Satzzeichen.
+ :Fokus: Unterreihe, Bruckentasten und Satzzeichen.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)d&c&k&m - Ubung 1
+D:dc km dc km dc km dc km dc km dc km dc km dc km dc km dc km
+I:(2)c&o&m&e&a&l - Ubung 2
+D:come calm come calm come calm come calm come calm come calm
+I:(3)m&a&k&e&c&l&o&v&s - Ubung 3
+D:make calm moves make calm moves make calm moves make calm moves
+
+G:RIVER_GATE
+
+*:DAY_16
+B:KeyQuest - Tag 16 - River Gate: Valley Reach
+T:Tag 16 guidance.
+ :Bogen: River Gate. Unterreihe, Bruckentasten und Satzzeichen.
+ :Fokus: Unterreihe, Bruckentasten und Satzzeichen.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)f&v&j&n - Ubung 1
+D:fv jn fv jn fv jn fv jn fv jn fv jn fv jn fv jn fv jn fv jn
+I:(2)e&v&n&i - Ubung 2
+D:even nine even nine even nine even nine even nine even nine
+I:(3)m&o&v&e&n&r&a&i&s&h - Ubung 3
+D:move never vanish move never vanish move never vanish
+
+G:RIVER_GATE
+
+*:DAY_17
+B:KeyQuest - Tag 17 - River Gate: Bridge Keys
+T:Tag 17 guidance.
+ :Bogen: River Gate. Unterreihe, Bruckentasten und Satzzeichen.
+ :Fokus: Unterreihe, Bruckentasten und Satzzeichen.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)f&g&j&h&b&n - Ubung 1
+D:fg jh fb jn fg jh fb jn fg jh fb jn fg jh fb jn fg jh fb jn
+I:(2)b&r&i&n&g&h&t - Ubung 2
+D:bring bright bring bright bring bright bring bright
+I:(3)b&e&g&i&n&t&h&r&d - Ubung 3
+D:begin the bridge begin the bridge begin the bridge begin the bridge
+
+G:RIVER_GATE
+
+*:DAY_18
+B:KeyQuest - Tag 18 - River Gate: Comma And Period
+T:Tag 18 guidance.
+ :Bogen: River Gate. Unterreihe, Bruckentasten und Satzzeichen.
+ :Fokus: Unterreihe, Bruckentasten und Satzzeichen.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)k&,&l&. - Ubung 1
+D:k, l. k, l. k, l. k, l. k, l. k, l. k, l. k, l. k, l. k, l.
+I:(2)c&a&l&m&,&s&t&e&d&y&. - Ubung 2
+D:calm, steady. calm, steady. calm, steady. calm, steady.
+I:(3)m&o&v&e&,&r&s&t&. - Ubung 3
+D:move, rest. move, rest. move, rest. move, rest.
+
+G:RIVER_GATE
+
+*:DAY_19
+B:KeyQuest - Tag 19 - River Gate: Bottom Row Words
+T:Tag 19 guidance.
+ :Bogen: River Gate. Unterreihe, Bruckentasten und Satzzeichen.
+ :Fokus: Unterreihe, Bruckentasten und Satzzeichen.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)b&r&a&v&e&m&o&c&l - Ubung 1
+D:brave move calm brave move calm brave move calm brave move calm
+I:(2)n&e&v&r&b&i&g&p&a&c - Ubung 2
+D:never bring panic never bring panic never bring panic
+I:(3)s&t&e&a&d&y&r&i&v&,&b&h - Ubung 3
+D:steady river, brave hands. steady river, brave hands.
+
+G:RIVER_GATE
+
+*:DAY_20
+B:KeyQuest - Tag 20 - River Gate: Current Review
+T:Tag 20 guidance.
+ :Bogen: River Gate. Unterreihe, Bruckentasten und Satzzeichen.
+ :Fokus: Unterreihe, Bruckentasten und Satzzeichen.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)q&w&e&r&a&s&d&f&z&x&c&v - Ubung 1
+D:qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv
+I:(2)u&i&o&p&j&k&l&;&n&m&,&. - Ubung 2
+D:uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,.
+I:(3)b&r&i&n&g&c&a&l&m&,&o&v - Ubung 3
+D:bring calm, move steady. bring calm, move steady.
+
+G:RIVER_GATE
+
+*:DAY_21
+B:KeyQuest - Tag 21 - River Gate: Ferryman Trial
+T:Tag 21 guidance.
+ :Bogen: River Gate. Unterreihe, Bruckentasten und Satzzeichen.
+ :Fokus: Unterreihe, Bruckentasten und Satzzeichen.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)a&s&d&f&q&w&e&r&z&x&c&v - Ubung 1
+D:asdf qwer zxcv asdf qwer zxcv asdf qwer zxcv asdf qwer zxcv
+I:(2)j&k&l&;&u&i&o&p&n&m&,&. - Ubung 2
+D:jkl; uiop nm,. jkl; uiop nm,. jkl; uiop nm,. jkl; uiop nm,.
+I:(3)n&e&v&r&p&a&i&c&,&m&o&s - Ubung 3
+D:never panic, move steady. never panic, move steady.
+I:(4)b&r&a&v&e&h&n&d&s&c&o&t - Ubung 4
+D:brave hands cross the quiet river. brave hands cross the quiet river.
+
+G:RIVER_GATE
+
+*:DAY_22
+B:KeyQuest - Tag 22 - Lantern Keep: Left Number Row
+T:Tag 22 guidance.
+ :Bogen: Lantern Keep. Zahlenreihe und praktische Zahlenfolgen.
+ :Fokus: Zahlenreihe und praktische Zahlenfolgen.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)1&2&3&4 - Ubung 1
+D:1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4
+I:(2)1&2&3&4 - Ubung 2
+D:11 22 33 44 11 22 33 44 11 22 33 44 11 22 33 44 11 22 33 44
+I:(3)r&o&m&1&2&g&a&t&e&3&4 - Ubung 3
+D:room 12 gate 34 room 12 gate 34 room 12 gate 34 room 12 gate 34
+
+G:LANTERN_KEEP
+
+*:DAY_23
+B:KeyQuest - Tag 23 - Lantern Keep: Right Number Row
+T:Tag 23 guidance.
+ :Bogen: Lantern Keep. Zahlenreihe und praktische Zahlenfolgen.
+ :Fokus: Zahlenreihe und praktische Zahlenfolgen.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)7&8&9&0 - Ubung 1
+D:7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0
+I:(2)7&8&9&0 - Ubung 2
+D:77 88 99 00 77 88 99 00 77 88 99 00 77 88 99 00 77 88 99 00
+I:(3)t&o&w&e&r&7&8&p&a&h&9&0 - Ubung 3
+D:tower 78 path 90 tower 78 path 90 tower 78 path 90 tower 78 path 90
+
+G:LANTERN_KEEP
+
+*:DAY_24
+B:KeyQuest - Tag 24 - Lantern Keep: Center Span
+T:Tag 24 guidance.
+ :Bogen: Lantern Keep. Zahlenreihe und praktische Zahlenfolgen.
+ :Fokus: Zahlenreihe und praktische Zahlenfolgen.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)4&5&6&7 - Ubung 1
+D:4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7
+I:(2)4&5&6&7 - Ubung 2
+D:45 56 67 76 65 54 45 56 67 76 65 54 45 56 67 76 65 54
+I:(3)l&e&v&4&5&b&r&i&d&g&6&7 - Ubung 3
+D:level 45 bridge 67 level 45 bridge 67 level 45 bridge 67
+
+G:LANTERN_KEEP
+
+*:DAY_25
+B:KeyQuest - Tag 25 - Lantern Keep: Counts And Codes
+T:Tag 25 guidance.
+ :Bogen: Lantern Keep. Zahlenreihe und praktische Zahlenfolgen.
+ :Fokus: Zahlenreihe und praktische Zahlenfolgen.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)t&a&k&e&2&y&s&3&m&p - Ubung 1
+D:take 2 keys and 3 maps take 2 keys and 3 maps
+I:(2)m&a&r&k&4&o&s&b&e&f&5 - Ubung 2
+D:mark 4 rooms before 5 mark 4 rooms before 5 mark 4 rooms before 5
+I:(3)c&o&d&e&1&2&0&p&n&s&g&a - Ubung 3
+D:code 120 opens gate 34 code 120 opens gate 34
+
+G:LANTERN_KEEP
+
+*:DAY_26
+B:KeyQuest - Tag 26 - Lantern Keep: Map Marks
+T:Tag 26 guidance.
+ :Bogen: Lantern Keep. Zahlenreihe und praktische Zahlenfolgen.
+ :Fokus: Zahlenreihe und praktische Zahlenfolgen.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)m&a&p&1&r&o&2&h&l&3 - Ubung 1
+D:map 1 room 2 hall 3 map 1 room 2 hall 3 map 1 room 2 hall 3
+I:(2)t&u&r&n&6&h&e&o&p&7 - Ubung 2
+D:turn 6 then open 7 turn 6 then open 7 turn 6 then open 7
+I:(3)l&a&m&p&8&s&h&o&w&d&r&9 - Ubung 3
+D:lamp 8 shows door 9 lamp 8 shows door 9 lamp 8 shows door 9
+
+G:LANTERN_KEEP
+
+*:DAY_27
+B:KeyQuest - Tag 27 - Lantern Keep: Mixed Signals
+T:Tag 27 guidance.
+ :Bogen: Lantern Keep. Zahlenreihe und praktische Zahlenfolgen.
+ :Fokus: Zahlenreihe und praktische Zahlenfolgen.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)l&e&v&2&m&a&p&4&g&t&6 - Ubung 1
+D:level 2 map 4 gate 6 level 2 map 4 gate 6 level 2 map 4 gate 6
+I:(2)p&a&t&h&8&r&o&m&1&0 - Ubung 2
+D:path 8 room 10 path 8 room 10 path 8 room 10 path 8 room 10
+I:(3)s&t&e&a&d&y&h&n&r&i&g&l - Ubung 3
+D:steady hands read signal 27 steady hands read signal 27
+
+G:LANTERN_KEEP
+
+*:DAY_28
+B:KeyQuest - Tag 28 - Lantern Keep: Beacon Trial
+T:Tag 28 guidance.
+ :Bogen: Lantern Keep. Zahlenreihe und praktische Zahlenfolgen.
+ :Fokus: Zahlenreihe und praktische Zahlenfolgen.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)1&2&3&4&5&6&7&8&9&0 - Ubung 1
+D:1234 567 890 1234 567 890 1234 567 890 1234 567 890 1234 567 890
+I:(2)g&a&t&e&1&2&r&o&m&3&4&p - Ubung 2
+D:gate 12 room 34 path 56 gate 12 room 34 path 56
+I:(3)m&a&r&k&7&8&t&h&e&n&o&p - Ubung 3
+D:mark 78 then open 90 mark 78 then open 90 mark 78 then open 90
+I:(4)t&h&e&b&a&c&o&n&p&s&l&v - Ubung 4
+D:the beacon opens at level 28. the beacon opens at level 28.
+
+G:LANTERN_KEEP
+
+*:DAY_29
+B:KeyQuest - Tag 29 - Ashen Forge: Left Shift Spark
+T:Tag 29 guidance.
+ :Bogen: Ashen Forge. Shift-Tasten und Grossbuchstaben.
+ :Fokus: Shift-Tasten und Grossbuchstaben.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)A&S&D&F - Ubung 1
+D:A S D F A S D F A S D F A S D F A S D F A S D F A S D F A S D F
+I:(2)A&a&S&s&D&d&F&f - Ubung 2
+D:A a S s D d F f A a S s D d F f A a S s D d F f A a S s D d F f
+I:(3)A&s&k&D&a&d&F&l&S&f&e - Ubung 3
+D:Ask Dad Fall Safe Ask Dad Fall Safe Ask Dad Fall Safe
+
+G:ASHEN_FORGE
+
+*:DAY_30
+B:KeyQuest - Tag 30 - Ashen Forge: Right Shift Spark
+T:Tag 30 guidance.
+ :Bogen: Ashen Forge. Shift-Tasten und Grossbuchstaben.
+ :Fokus: Shift-Tasten und Grossbuchstaben.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)J&K&L&H - Ubung 1
+D:J K L H J K L H J K L H J K L H J K L H J K L H J K L H J K L H
+I:(2)J&j&K&k&L&l&H&h - Ubung 2
+D:J j K k L l H h J j K k L l H h J j K k L l H h J j K k L l H h
+I:(3)J&o&y&K&e&L&a&k&H&i&l - Ubung 3
+D:Joy Key Lake Hill Joy Key Lake Hill Joy Key Lake Hill
+
+G:ASHEN_FORGE
+
+*:DAY_31
+B:KeyQuest - Tag 31 - Ashen Forge: Capital Names
+T:Tag 31 guidance.
+ :Bogen: Ashen Forge. Shift-Tasten und Grossbuchstaben.
+ :Fokus: Shift-Tasten und Grossbuchstaben.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)A&d&a&K&e&n&L&i&J&o - Ubung 1
+D:Ada Ken Lia Jo Ada Ken Lia Jo Ada Ken Lia Jo Ada Ken Lia Jo
+I:(2)M&i&r&a&N&o&V&l&e&O&w&n - Ubung 2
+D:Mira Nora Vale Owen Mira Nora Vale Owen Mira Nora Vale Owen
+I:(3)A&d&a&n&K&e&r - Ubung 3
+D:Ada and Ken read Ada and Ken read Ada and Ken read Ada and Ken read
+
+G:ASHEN_FORGE
+
+*:DAY_32
+B:KeyQuest - Tag 32 - Ashen Forge: Sentence Starts
+T:Tag 32 guidance.
+ :Bogen: Ashen Forge. Shift-Tasten und Grossbuchstaben.
+ :Fokus: Shift-Tasten und Grossbuchstaben.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)K&e&p&c&a&l&m&.&H&o&d&h - Ubung 1
+D:Keep calm. Hold home. Type true.
+I:(2)T&h&e&f&o&r&g&l&w&s&.&k - Ubung 2
+D:The forge glows. The key cools.
+I:(3)S&t&a&r&e&c&h&l&i&n&w&. - Ubung 3
+D:Start each line with care.
+
+G:ASHEN_FORGE
+
+*:DAY_33
+B:KeyQuest - Tag 33 - Ashen Forge: Title Case
+T:Tag 33 guidance.
+ :Bogen: Ashen Forge. Shift-Tasten und Grossbuchstaben.
+ :Fokus: Shift-Tasten und Grossbuchstaben.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)A&s&h&e&n&F&o&r&g - Ubung 1
+D:Ashen Forge Ashen Forge Ashen Forge Ashen Forge Ashen Forge
+I:(2)S&i&l&v&e&r&K&y&Q&u&t&G - Ubung 2
+D:Silver Key Quiet Gate Silver Key Quiet Gate Silver Key Quiet Gate
+I:(3)T&h&e&B&r&i&g&t&A&n&v&l - Ubung 3
+D:The Bright Anvil Shapes The Silent Key
+
+G:ASHEN_FORGE
+
+*:DAY_34
+B:KeyQuest - Tag 34 - Ashen Forge: Shift Review
+T:Tag 34 guidance.
+ :Bogen: Ashen Forge. Shift-Tasten und Grossbuchstaben.
+ :Fokus: Shift-Tasten und Grossbuchstaben.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)A&j&S&k&D&l&F&h - Ubung 1
+D:A j S k D l F h A j S k D l F h A j S k D l F h A j S k D l F h
+I:(2)C&a&l&m&H&n&d&s&S&h&p&e - Ubung 2
+D:Calm Hands Shape Bright Keys
+I:(3)A&s&t&e&a&d&y&h&n&c&l&i - Ubung 3
+D:A steady hand can lift every letter.
+
+G:ASHEN_FORGE
+
+*:DAY_35
+B:KeyQuest - Tag 35 - Ashen Forge: Anvil Trial
+T:Tag 35 guidance.
+ :Bogen: Ashen Forge. Shift-Tasten und Grossbuchstaben.
+ :Fokus: Shift-Tasten und Grossbuchstaben.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)A&S&D&F&J&K&L&H - Ubung 1
+D:A S D F J K L H A S D F J K L H A S D F J K L H A S D F J K L H
+I:(2)A&d&a&K&e&n&M&i&r&O&w - Ubung 2
+D:Ada Ken Mira Owen Ada Ken Mira Owen Ada Ken Mira Owen
+I:(3)T&h&e&A&s&n&F&o&r&g&a&p - Ubung 3
+D:The Ashen Forge shapes a calm bright key.
+I:(4)H&o&l&d&h&m&e&,&t&a&p&S - Ubung 4
+D:Hold home, tap Shift, and let the anvil ring.
+
+G:ASHEN_FORGE
+
+*:DAY_36
+B:KeyQuest - Tag 36 - Windspire: Even Steps
+T:Tag 36 guidance.
+ :Bogen: Windspire. Tempokontrolle und Rhythmus.
+ :Fokus: Tempokontrolle und Rhythmus.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)t&a&p&r&e&s - Ubung 1
+D:tap rest tap rest tap rest tap rest tap rest tap rest
+I:(2)c&a&l&m&p&e&s&t&d&y - Ubung 2
+D:calm pace steady pace calm pace steady pace calm pace steady pace
+I:(3)E&v&e&r&y&s&m&a&l&t&p&k - Ubung 3
+D:Every small step keeps the wind in time.
+
+G:WINDSPIRE
+
+*:DAY_37
+B:KeyQuest - Tag 37 - Windspire: Short Bursts
+T:Tag 37 guidance.
+ :Bogen: Windspire. Tempokontrolle und Rhythmus.
+ :Fokus: Tempokontrolle und Rhythmus.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)f&a&s&t&o&p&c&l&m&g - Ubung 1
+D:fast stop calm go fast stop calm go fast stop calm go
+I:(2)w&i&n&d&r&u&s&t&h&e - Ubung 2
+D:wind runs then rests wind runs then rests wind runs then rests
+I:(3)B&u&r&s&t&f&o&a&m&e&n&, - Ubung 3
+D:Burst for a moment, then return to calm hands.
+
+G:WINDSPIRE
+
+*:DAY_38
+B:KeyQuest - Tag 38 - Windspire: Long Cadence
+T:Tag 38 guidance.
+ :Bogen: Windspire. Tempokontrolle und Rhythmus.
+ :Fokus: Tempokontrolle und Rhythmus.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)t&h&e&w&i&n&d&c&a&r&s&q - Ubung 1
+D:the wind carries a quiet rhythm over the road
+I:(2)s&t&e&a&d&y&f&i&n&g&r&c - Ubung 2
+D:steady fingers cross the high bridge with care
+I:(3)p&a&c&e&t&h&l&i&n&s&o&v - Ubung 3
+D:pace the line so every word lands cleanly
+
+G:WINDSPIRE
+
+*:DAY_39
+B:KeyQuest - Tag 39 - Windspire: Alternate Pace
+T:Tag 39 guidance.
+ :Bogen: Windspire. Tempokontrolle und Rhythmus.
+ :Fokus: Tempokontrolle und Rhythmus.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)s&l&o&w&q&u&i&c&k - Ubung 1
+D:slow slow quick quick slow slow quick quick slow slow quick quick
+I:(2)c&a&l&m&b&r&i&g&h&t - Ubung 2
+D:calm calm bright bright calm calm bright bright
+I:(3)C&h&a&n&g&e&p&c&o&l&y&w - Ubung 3
+D:Change pace only when the hands stay quiet.
+
+G:WINDSPIRE
+
+*:DAY_40
+B:KeyQuest - Tag 40 - Windspire: Breath Marks
+T:Tag 40 guidance.
+ :Bogen: Windspire. Tempokontrolle und Rhythmus.
+ :Fokus: Tempokontrolle und Rhythmus.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)b&r&e&a&t&h&,&y&p&u&s&. - Ubung 1
+D:breathe, type, pause. breathe, type, pause.
+I:(2)s&h&o&r&t&w&i&n&d&,&l&g - Ubung 2
+D:short wind, long road. calm hands, clean words.
+I:(3)L&e&t&a&c&h&o&m&s&l&w&r - Ubung 3
+D:Let each comma slow the run.
+
+G:WINDSPIRE
+
+*:DAY_41
+B:KeyQuest - Tag 41 - Windspire: Gale Review
+T:Tag 41 guidance.
+ :Bogen: Windspire. Tempokontrolle und Rhythmus.
+ :Fokus: Tempokontrolle und Rhythmus.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)q&w&e&r&a&s&d&f&z&x&c&v - Ubung 1
+D:qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv
+I:(2)u&i&o&p&j&k&l&;&n&m&,&. - Ubung 2
+D:uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,.
+I:(3)s&t&e&a&d&y&p&c&o&v&r&1 - Ubung 3
+D:steady pace over 12 stones and 34 rails
+
+G:WINDSPIRE
+
+*:DAY_42
+B:KeyQuest - Tag 42 - Windspire: Gale Trial
+T:Tag 42 guidance.
+ :Bogen: Windspire. Tempokontrolle und Rhythmus.
+ :Fokus: Tempokontrolle und Rhythmus.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)t&a&p&r&e&s&q&u&i&c&k&l - Ubung 1
+D:tap rest quick calm tap rest quick calm tap rest quick calm
+I:(2)t&h&e&w&i&n&d&r&s&b&u&a - Ubung 2
+D:the wind rises but the hands stay steady
+I:(3)q&u&i&c&k&s&t&e&p&a&r&f - Ubung 3
+D:quick steps are useful only when accuracy holds
+I:(4)r&i&d&e&t&h&g&a&l&w&y&m - Ubung 4
+D:ride the gale with rhythm, not panic.
+
+G:WINDSPIRE
+
+*:DAY_43
+B:KeyQuest - Tag 43 - Clockwork Citadel: Parentheses
+T:Tag 43 guidance.
+ :Bogen: Clockwork Citadel. Programmierpaare und Klammern.
+ :Fokus: Programmierpaare und Klammern.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)(&) - Ubung 1
+D:( ) () ( ) () ( ) () ( ) () ( ) () ( ) () ( ) () ( ) () ( ) ()
+I:(2)(&a&)&k&e&y&m&p - Ubung 2
+D:(a) (key) (map) (a) (key) (map) (a) (key) (map) (a) (key) (map)
+I:(3)o&p&e&n&(&t&h&g&a&)&d&c - Ubung 3
+D:open (the gate) and close (the lock)
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_44
+B:KeyQuest - Tag 44 - Clockwork Citadel: Brackets
+T:Tag 44 guidance.
+ :Bogen: Clockwork Citadel. Programmierpaare und Klammern.
+ :Fokus: Programmierpaare und Klammern.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)[&] - Ubung 1
+D:[ ] [] [ ] [] [ ] [] [ ] [] [ ] [] [ ] [] [ ] [] [ ] [] [ ] []
+I:(2)[&1&]&2&k&e&y - Ubung 2
+D:[1] [2] [key] [1] [2] [key] [1] [2] [key] [1] [2] [key]
+I:(3)m&a&r&k&[&o&]&t&h&e&n&d - Ubung 3
+D:mark [room] then read [signal]
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_45
+B:KeyQuest - Tag 45 - Clockwork Citadel: Braces
+T:Tag 45 guidance.
+ :Bogen: Clockwork Citadel. Programmierpaare und Klammern.
+ :Fokus: Programmierpaare und Klammern.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1){&} - Ubung 1
+D:{ } {} { } {} { } {} { } {} { } {} { } {} { } {} { } {} { } {}
+I:(2){&k&e&y&}&g&a&t&m&p - Ubung 2
+D:{key} {gate} {map} {key} {gate} {map} {key} {gate} {map}
+I:(3)s&t&o&r&e&{&l&i&g&h&}&b - Ubung 3
+D:store {light} before {shadow}
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_46
+B:KeyQuest - Tag 46 - Clockwork Citadel: Angle Gates
+T:Tag 46 guidance.
+ :Bogen: Clockwork Citadel. Programmierpaare und Klammern.
+ :Fokus: Programmierpaare und Klammern.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)<&> - Ubung 1
+D:< > <> < > <> < > <> < > <> < > <> < > <> < > <> < > <> < > <>
+I:(2)<&k&e&y&>&g&a&t&p&h - Ubung 2
+D:<key> <gate> <path> <key> <gate> <path> <key> <gate> <path>
+I:(3)r&e&a&d&<&s&i&g&n&l&>&b - Ubung 3
+D:read <signal> before <system> moves
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_47
+B:KeyQuest - Tag 47 - Clockwork Citadel: Nested Pairs
+T:Tag 47 guidance.
+ :Bogen: Clockwork Citadel. Programmierpaare und Klammern.
+ :Fokus: Programmierpaare und Klammern.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)(&[&]&)&{&} - Ubung 1
+D:([]) ({}) ([]) ({}) ([]) ({}) ([]) ({}) ([]) ({}) ([]) ({})
+I:(2)[&m&a&p&]&(&r&o&)&{&k&e - Ubung 2
+D:[map](room) {key} [map](room) {key} [map](room) {key}
+I:(3)o&p&e&n&(&[&q&u&i&t&]&) - Ubung 3
+D:open ([quiet]) gears with {steady} hands
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_48
+B:KeyQuest - Tag 48 - Clockwork Citadel: Gear Review
+T:Tag 48 guidance.
+ :Bogen: Clockwork Citadel. Programmierpaare und Klammern.
+ :Fokus: Programmierpaare und Klammern.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)(&)&[&]&{&}&<&> - Ubung 1
+D:() [] {} <> () [] {} <> () [] {} <> () [] {} <> () [] {} <>
+I:(2)g&e&a&r&[&1&]&t&u&n&s&( - Ubung 2
+D:gear[1] turns (slow) while {hands} return
+I:(3)c&l&o&k&w&r&e&y&s&n&d&p - Ubung 3
+D:clockwork keys need paired symbols in order
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_49
+B:KeyQuest - Tag 49 - Clockwork Citadel: Gearheart Trial
+T:Tag 49 guidance.
+ :Bogen: Clockwork Citadel. Programmierpaare und Klammern.
+ :Fokus: Programmierpaare und Klammern.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)(&)&[&]&{&}&<&> - Ubung 1
+D:() [] {} <> () [] {} <> () [] {} <> () [] {} <> () [] {} <>
+I:(2)o&p&e&n&(&g&a&r&)&t&h&c - Ubung 2
+D:open (gear) then close [vault] with {care}
+I:(3)t&h&e&<&g&a&r&>&c&p&s&l - Ubung 3
+D:the <gearheart> accepts clean paired keys
+I:(4)m&a&t&c&h&e&v&r&y&b&k&f - Ubung 4
+D:match every bracket before the engine wakes.
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_50
+B:KeyQuest - Tag 50 - Starfall Library: Math Signs
+T:Tag 50 guidance.
+ :Bogen: Starfall Library. Symbole, Operatoren und codeahnlicher Fluss.
+ :Fokus: Symbole, Operatoren und codeahnlicher Fluss.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)1&+&2&=&3 - Ubung 1
+D:1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3
+I:(2)4&-&1&=&3 - Ubung 2
+D:4 - 1 = 3 4 - 1 = 3 4 - 1 = 3 4 - 1 = 3 4 - 1 = 3 4 - 1 = 3
+I:(3)l&i&g&h&t&+&f&o&c&u&s&= - Ubung 3
+D:light + focus = clear typing
+
+G:STARFALL_LIBRARY
+
+*:DAY_51
+B:KeyQuest - Tag 51 - Starfall Library: Slash And Star
+T:Tag 51 guidance.
+ :Bogen: Starfall Library. Symbole, Operatoren und codeahnlicher Fluss.
+ :Fokus: Symbole, Operatoren und codeahnlicher Fluss.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)/&* - Ubung 1
+D:/ * / * / * / * / * / * / * / * / * / * / * / * / * / * / * / *
+I:(2)p&a&t&h&/&m&s&r&*&k&e&y - Ubung 2
+D:path / map star * key path / map star * key path / map star * key
+I:(3)r&e&a&d&/&s&l&o&w&y&n&m - Ubung 3
+D:read / slowly and mark * carefully
+
+G:STARFALL_LIBRARY
+
+*:DAY_52
+B:KeyQuest - Tag 52 - Starfall Library: Quotes
+T:Tag 52 guidance.
+ :Bogen: Starfall Library. Symbole, Operatoren und codeahnlicher Fluss.
+ :Fokus: Symbole, Operatoren und codeahnlicher Fluss.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)"&k&e&y&m&a&p - Ubung 1
+D:"key" "map" "key" "map" "key" "map" "key" "map" "key" "map"
+I:(2)'&g&o&r&e&s&t - Ubung 2
+D:'go' 'rest' 'go' 'rest' 'go' 'rest' 'go' 'rest' 'go' 'rest'
+I:(3)t&h&e&s&i&g&n&a&y&"&o&l - Ubung 3
+D:the sign says "hold steady" before moving
+
+G:STARFALL_LIBRARY
+
+*:DAY_53
+B:KeyQuest - Tag 53 - Starfall Library: Colon Signals
+T:Tag 53 guidance.
+ :Bogen: Starfall Library. Symbole, Operatoren und codeahnlicher Fluss.
+ :Fokus: Symbole, Operatoren und codeahnlicher Fluss.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)k&e&y&:&g&a&t&;&m&p&h - Ubung 1
+D:key: gate; map: path; key: gate; map: path; key: gate; map: path;
+I:(2)n&o&t&e&:&b&r&a&h&;&y&p - Ubung 2
+D:note: breathe; type: slowly; check: accuracy;
+I:(3)s&i&g&n&a&l&:&c&e&r&;&h - Ubung 3
+D:signal: clear; hands: calm; route: open;
+
+G:STARFALL_LIBRARY
+
+*:DAY_54
+B:KeyQuest - Tag 54 - Starfall Library: Code Words
+T:Tag 54 guidance.
+ :Bogen: Starfall Library. Symbole, Operatoren und codeahnlicher Fluss.
+ :Fokus: Symbole, Operatoren und codeahnlicher Fluss.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)i&f&g&a&t&e&=&o&p&n&h&y - Ubung 1
+D:if gate = open then type calm words
+I:(2)c&o&u&n&t&+&f&s&-&p&a&i - Ubung 2
+D:count + focus - panic = steady hands
+I:(3)p&a&t&h&/&r&o&m&k&e&y&s - Ubung 3
+D:path / room / key keeps the record clear
+
+G:STARFALL_LIBRARY
+
+*:DAY_55
+B:KeyQuest - Tag 55 - Starfall Library: Archive Review
+T:Tag 55 guidance.
+ :Bogen: Starfall Library. Symbole, Operatoren und codeahnlicher Fluss.
+ :Fokus: Symbole, Operatoren und codeahnlicher Fluss.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)1&+&2&=&3&;&4&- - Ubung 1
+D:1 + 2 = 3; 4 - 1 = 3; 1 + 2 = 3; 4 - 1 = 3; 1 + 2 = 3; 4 - 1 = 3;
+I:(2)r&e&c&o&d&:&"&s&t&a&y&; - Ubung 2
+D:record: "steady"; status: "clear";
+I:(3)t&h&e&a&r&c&i&v&o&p&n&s - Ubung 3
+D:the archive opens when symbols stay in order
+
+G:STARFALL_LIBRARY
+
+*:DAY_56
+B:KeyQuest - Tag 56 - Starfall Library: Archivist Trial
+T:Tag 56 guidance.
+ :Bogen: Starfall Library. Symbole, Operatoren und codeahnlicher Fluss.
+ :Fokus: Symbole, Operatoren und codeahnlicher Fluss.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)k&e&y&+&m&a&p&=&t&h&;&c - Ubung 1
+D:key + map = path; path + calm = progress;
+I:(2)r&e&a&d&"&s&i&g&n&l&/&m - Ubung 2
+D:read "signal" / mark "gate" / hold focus
+I:(3)i&f&r&o&m&=&c&l&e&a&t&h - Ubung 3
+D:if room = clear then move slowly.
+I:(4)t&h&e&a&r&c&i&v&s&u&y&m - Ubung 4
+D:the archivist trusts accurate symbols.
+
+G:STARFALL_LIBRARY
+
+*:DAY_57
+B:KeyQuest - Tag 57 - Dragon Spine: Pressure Warmup
+T:Tag 57 guidance.
+ :Bogen: Dragon Spine. Genauigkeit unter Druck.
+ :Fokus: Genauigkeit unter Druck.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)h&o&l&d&c&a&m&t&y&p&e&r - Ubung 1
+D:hold calm type true hold calm type true hold calm type true
+I:(2)t&h&e&r&i&d&g&s&b&u&a&n - Ubung 2
+D:the ridge is high but the hands stay low
+I:(3)a&c&u&r&y&i&s&t&h&e&l&d - Ubung 3
+D:accuracy is the shield before speed.
+
+G:DRAGON_SPINE
+
+*:DAY_58
+B:KeyQuest - Tag 58 - Dragon Spine: Longer Climb
+T:Tag 58 guidance.
+ :Bogen: Dragon Spine. Genauigkeit unter Druck.
+ :Fokus: Genauigkeit unter Druck.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)t&h&e&d&r&a&g&o&n&i&s&b - Ubung 1
+D:the dragon road rises beyond the quiet stone gate
+I:(2)e&a&c&h&r&f&u&l&w&o&d&k - Ubung 2
+D:each careful word keeps the traveler on the ridge
+I:(3)f&i&n&s&h&t&e&l&a&c&y&b - Ubung 3
+D:finish the line as cleanly as it began
+
+G:DRAGON_SPINE
+
+*:DAY_59
+B:KeyQuest - Tag 59 - Dragon Spine: Heat Control
+T:Tag 59 guidance.
+ :Bogen: Dragon Spine. Genauigkeit unter Druck.
+ :Fokus: Genauigkeit unter Druck.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)G&a&t&e&1&2&o&p&n&s&f&r - Ubung 1
+D:Gate 12 opens after Signal 34.
+I:(2)D&r&a&g&o&n&7&c&i&l&e&s - Ubung 2
+D:Dragon 7 circles Tower 9 before dawn.
+I:(3)K&e&p&3&c&a&l&m&b&r&t&h - Ubung 3
+D:Keep 3 calm breaths before Route 5.
+
+G:DRAGON_SPINE
+
+*:DAY_60
+B:KeyQuest - Tag 60 - Dragon Spine: No Panic
+T:Tag 60 guidance.
+ :Bogen: Dragon Spine. Genauigkeit unter Druck.
+ :Fokus: Genauigkeit unter Druck.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)b&r&e&a&t&h&,&c&o&n&i&u - Ubung 1
+D:breathe, correct, continue; do not chase the error.
+I:(2)t&h&e&o&p&a&b&n&d&s&,&u - Ubung 2
+D:the hot path bends, but steady fingers recover.
+I:(3)s&l&o&w&c&r&e&t&i&n&b&a - Ubung 3
+D:slow correction beats fast panic every time.
+
+G:DRAGON_SPINE
+
+*:DAY_61
+B:KeyQuest - Tag 61 - Dragon Spine: Focus Run
+T:Tag 61 guidance.
+ :Bogen: Dragon Spine. Genauigkeit unter Druck.
+ :Fokus: Genauigkeit unter Druck.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)T&h&e&b&r&i&g&t&d&n&a&o - Ubung 1
+D:The bright ridge narrows as the old dragon wakes.
+I:(2)A&c&a&l&m&t&r&v&e&d&s&h - Ubung 2
+D:A calm traveler reads the wind and keeps moving.
+I:(3)E&v&e&r&y&c&l&a&n&w&o&d - Ubung 3
+D:Every clean word becomes another safe step.
+
+G:DRAGON_SPINE
+
+*:DAY_62
+B:KeyQuest - Tag 62 - Dragon Spine: Wyrm Review
+T:Tag 62 guidance.
+ :Bogen: Dragon Spine. Genauigkeit unter Druck.
+ :Fokus: Genauigkeit unter Druck.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)R&o&u&t&e&4&2&:&c&l&i&m - Ubung 1
+D:Route 42: climb, pause, breathe, continue.
+I:(2)T&h&e&r&i&d&g&m&a&k&s&y - Ubung 2
+D:The ridge marker says "steady hands survive."
+I:(3)f&o&c&u&s&+&p&a&t&i&e&n - Ubung 3
+D:focus + patience = safe travel under pressure
+
+G:DRAGON_SPINE
+
+*:DAY_63
+B:KeyQuest - Tag 63 - Dragon Spine: Wyrm Trial
+T:Tag 63 guidance.
+ :Bogen: Dragon Spine. Genauigkeit unter Druck.
+ :Fokus: Genauigkeit unter Druck.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)T&h&e&d&r&a&g&o&n&w&t&c - Ubung 1
+D:The dragon watches each key and every pause.
+I:(2)R&o&u&t&e&6&3&i&s&n&a&r - Ubung 2
+D:Route 63 is narrow, bright, and unforgiving.
+I:(3)B&r&e&a&t&h&,&y&p&c&o&v - Ubung 3
+D:Breathe, type, recover; the ridge will not hurry.
+I:(4)T&h&e&w&y&r&m&i&l&d&s&t - Ubung 4
+D:The wyrm yields to calm accurate hands.
+
+G:DRAGON_SPINE
+
+*:DAY_64
+B:KeyQuest - Tag 64 - Moonlit Labyrinth: Slow Repair
+T:Tag 64 guidance.
+ :Bogen: Moonlit Labyrinth. schwache Tasten ruhig korrigieren.
+ :Fokus: schwache Tasten ruhig korrigieren.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)q&z&p&; - Ubung 1
+D:q z p ; q z p ; q z p ; q z p ; q z p ; q z p ; q z p ; q z p ;
+I:(2)v&b&n&m - Ubung 2
+D:v b n m v b n m v b n m v b n m v b n m v b n m v b n m v b n m
+I:(3)s&l&o&w&r&e&p&a&i&m&k&t - Ubung 3
+D:slow repair makes the lost path visible
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_65
+B:KeyQuest - Tag 65 - Moonlit Labyrinth: Outer Keys
+T:Tag 65 guidance.
+ :Bogen: Moonlit Labyrinth. schwache Tasten ruhig korrigieren.
+ :Fokus: schwache Tasten ruhig korrigieren.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)q&a&;&p - Ubung 1
+D:qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p
+I:(2)z&q&p&; - Ubung 2
+D:zq p; zq p; zq p; zq p; zq p; zq p; zq p; zq p; zq p; zq p;
+I:(3)q&u&i&e&t&p&a&h&s&b&y&o - Ubung 3
+D:quiet paths pass beyond pale pillars
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_66
+B:KeyQuest - Tag 66 - Moonlit Labyrinth: Bottom Repair
+T:Tag 66 guidance.
+ :Bogen: Moonlit Labyrinth. schwache Tasten ruhig korrigieren.
+ :Fokus: schwache Tasten ruhig korrigieren.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)c&v&n&m&b - Ubung 1
+D:cv nm vb cv nm vb cv nm vb cv nm vb cv nm vb cv nm vb cv nm vb
+I:(2)m&o&v&e&b&r&a&n&c&l - Ubung 2
+D:move brave never calm move brave never calm move brave never calm
+I:(3)t&h&e&m&a&z&b&n&d&s&l&o - Ubung 3
+D:the maze bends below the home row
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_67
+B:KeyQuest - Tag 67 - Moonlit Labyrinth: Symbol Repair
+T:Tag 67 guidance.
+ :Bogen: Moonlit Labyrinth. schwache Tasten ruhig korrigieren.
+ :Fokus: schwache Tasten ruhig korrigieren.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)(&)&[&]&{&} - Ubung 1
+D:() [] {} () [] {} () [] {} () [] {} () [] {} () [] {} () [] {}
+I:(2)1&+&2&=&3 - Ubung 2
+D:1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3
+I:(3)r&e&p&a&i&[&s&m&l&]&o&b - Ubung 3
+D:repair [small] errors before {large} ones
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_68
+B:KeyQuest - Tag 68 - Moonlit Labyrinth: Mirror Paths
+T:Tag 68 guidance.
+ :Bogen: Moonlit Labyrinth. schwache Tasten ruhig korrigieren.
+ :Fokus: schwache Tasten ruhig korrigieren.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)a&s&d&f&j&k&l&; - Ubung 1
+D:asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj
+I:(2)q&w&e&r&u&i&o&p - Ubung 2
+D:qwer rewq uiop poiu qwer rewq uiop poiu qwer rewq uiop poiu
+I:(3)l&e&f&t&p&a&h&r&i&g&b&o - Ubung 3
+D:left path right path both return home
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_69
+B:KeyQuest - Tag 69 - Moonlit Labyrinth: Labyrinth Review
+T:Tag 69 guidance.
+ :Bogen: Moonlit Labyrinth. schwache Tasten ruhig korrigieren.
+ :Fokus: schwache Tasten ruhig korrigieren.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)q&u&i&e&t&z&b&r&a&p&h&s - Ubung 1
+D:quiet zebra paths puzzle every brave novice
+I:(2)s&y&m&b&o&l&,&n&u&e&r&a - Ubung 2
+D:symbols, numbers, and outer keys need patience.
+I:(3)c&o&r&e&t&h&s&m&a&l&i&b - Ubung 3
+D:correct the small miss before moving onward
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_70
+B:KeyQuest - Tag 70 - Moonlit Labyrinth: Minotaur Trial
+T:Tag 70 guidance.
+ :Bogen: Moonlit Labyrinth. schwache Tasten ruhig korrigieren.
+ :Fokus: schwache Tasten ruhig korrigieren.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)q&z&p&;&v&b&n&m - Ubung 1
+D:q z p ; v b n m q z p ; v b n m q z p ; v b n m q z p ; v b n m
+I:(2)q&u&i&e&t&s&y&m&b&o&l&[ - Ubung 2
+D:quiet symbols [return] after {careful} repair
+I:(3)t&h&e&m&a&z&r&w&d&s&p&i - Ubung 3
+D:the maze rewards patience, not panic.
+I:(4)r&e&c&o&v&a&h&k&y&n&d&l - Ubung 4
+D:recover each key and leave the labyrinth.
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_71
+B:KeyQuest - Tag 71 - Obsidian Throne: Mixed Marks
+T:Tag 71 guidance.
+ :Bogen: Obsidian Throne. gemischte Satzzeichen und Langform-Fokus.
+ :Fokus: gemischte Satzzeichen und Langform-Fokus.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)w&a&i&t&,&l&o&k&;&y&p&e - Ubung 1
+D:wait, look; type: slowly.
+I:(2)k&e&y&:&f&o&u&n&d&,&g&a - Ubung 2
+D:key: found, gate: open, path: clear.
+I:(3)t&h&e&r&o&n&i&s&d&a&k&; - Ubung 3
+D:the throne is dark; the signal is bright.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_72
+B:KeyQuest - Tag 72 - Obsidian Throne: Quote Orders
+T:Tag 72 guidance.
+ :Bogen: Obsidian Throne. gemischte Satzzeichen und Langform-Fokus.
+ :Fokus: gemischte Satzzeichen und Langform-Fokus.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)T&h&e&g&u&a&r&d&s&y&,&" - Ubung 1
+D:The guard says, "hold the line."
+I:(2)T&h&e&m&a&p&r&d&s&,&"&t - Ubung 2
+D:The map reads, "turn left, then pause."
+I:(3)S&h&e&w&i&s&p&r&,&"&a&c - Ubung 3
+D:She whispers, "accuracy breaks the seal."
+
+G:OBSIDIAN_THRONE
+
+*:DAY_73
+B:KeyQuest - Tag 73 - Obsidian Throne: Long Focus
+T:Tag 73 guidance.
+ :Bogen: Obsidian Throne. gemischte Satzzeichen und Langform-Fokus.
+ :Fokus: gemischte Satzzeichen und Langform-Fokus.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)B&e&y&o&n&d&t&h&b&l&a&c - Ubung 1
+D:Beyond the black hall, every comma becomes a breath.
+I:(2)T&h&e&o&l&d&c&r&w&n&a&i - Ubung 2
+D:The old crown waits; calm hands answer without fear.
+I:(3)A&l&o&n&g&i&e&s&y&v&r&a - Ubung 3
+D:A long line is only several small clean choices.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_74
+B:KeyQuest - Tag 74 - Obsidian Throne: Clause Chains
+T:Tag 74 guidance.
+ :Bogen: Obsidian Throne. gemischte Satzzeichen und Langform-Fokus.
+ :Fokus: gemischte Satzzeichen und Langform-Fokus.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)l&o&k&a&h&e&d&;&b&r&t&n - Ubung 1
+D:look ahead; breathe once; type the next word.
+I:(2)t&h&e&a&l&n&r&o&w&s&;&c - Ubung 2
+D:the hall narrows; the torch dims; focus remains.
+I:(3)s&l&o&w&h&a&n&d&i&;&r&u - Ubung 3
+D:slow hands win; rushed hands repeat the lesson.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_75
+B:KeyQuest - Tag 75 - Obsidian Throne: Dense Review
+T:Tag 75 guidance.
+ :Bogen: Obsidian Throne. gemischte Satzzeichen und Langform-Fokus.
+ :Fokus: gemischte Satzzeichen und Langform-Fokus.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)R&o&m&7&5&:&"&s&t&e&a&d - Ubung 1
+D:Room 75: "steady," says the silent crown.
+I:(2)G&a&t&e&3&o&p&n&s&;&4&w - Ubung 2
+D:Gate 3 opens; Gate 4 waits; Gate 5 listens.
+I:(3)c&l&e&a&r&m&k&s&,&n&w&o - Ubung 3
+D:clear marks, clean words, and calm recovery.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_76
+B:KeyQuest - Tag 76 - Obsidian Throne: Crown Approach
+T:Tag 76 guidance.
+ :Bogen: Obsidian Throne. gemischte Satzzeichen und Langform-Fokus.
+ :Fokus: gemischte Satzzeichen und Langform-Fokus.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)T&h&e&o&b&s&i&d&a&n&t&p - Ubung 1
+D:The obsidian steps rise slowly toward the throne.
+I:(2)E&a&c&h&m&r&k&t&e&s&:&o - Ubung 2
+D:Each mark matters: comma, period, colon, quote.
+I:(3)D&o&n&t&r&u&s&h&e&f&i&a - Ubung 3
+D:Do not rush the final line before the crown.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_77
+B:KeyQuest - Tag 77 - Obsidian Throne: Crown Trial
+T:Tag 77 guidance.
+ :Bogen: Obsidian Throne. gemischte Satzzeichen und Langform-Fokus.
+ :Fokus: gemischte Satzzeichen und Langform-Fokus.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)T&h&e&c&r&o&w&n&s&a&y&, - Ubung 1
+D:The crown says, "type clearly, then continue."
+I:(2)R&o&m&7&:&p&a&u&s&e&,&b - Ubung 2
+D:Room 77: pause, breathe, correct, proceed.
+I:(3)L&o&n&g&f&c&u&s&t&r&d&a - Ubung 3
+D:Long focus turns dark punctuation into light.
+I:(4)T&h&e&t&r&o&n&p&s&f&a&d - Ubung 4
+D:The throne opens for steady accurate hands.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_78
+B:KeyQuest - Tag 78 - Dawn Citadel: Full Keyboard Scan
+T:Tag 78 guidance.
+ :Bogen: Dawn Citadel. Wiederholung des ganzen Tastenfelds.
+ :Fokus: Wiederholung des ganzen Tastenfelds.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)q&w&e&r&a&s&d&f&z&x&c&v - Ubung 1
+D:qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv
+I:(2)u&i&o&p&j&k&l&;&n&m&,&. - Ubung 2
+D:uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,.
+I:(3)1&2&3&4&5&6&7&8&9&0 - Ubung 3
+D:1234 567 890 1234 567 890 1234 567 890 1234 567 890 1234 567 890
+
+G:DAWN_CITADEL
+
+*:DAY_79
+B:KeyQuest - Tag 79 - Dawn Citadel: Capital Review
+T:Tag 79 guidance.
+ :Bogen: Dawn Citadel. Wiederholung des ganzen Tastenfelds.
+ :Fokus: Wiederholung des ganzen Tastenfelds.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)D&a&w&n&C&i&t&d&e&l&o&p - Ubung 1
+D:Dawn Citadel opens Gate 79 with calm hands.
+I:(2)M&i&r&a&n&d&O&w&e&c&y&K - Ubung 2
+D:Mira and Owen carry Key 12 to Tower 34.
+I:(3)E&v&e&r&y&C&a&p&i&t&l&L - Ubung 3
+D:Every Capital Letter returns to home.
+
+G:DAWN_CITADEL
+
+*:DAY_80
+B:KeyQuest - Tag 80 - Dawn Citadel: Symbol Review
+T:Tag 80 guidance.
+ :Bogen: Dawn Citadel. Wiederholung des ganzen Tastenfelds.
+ :Fokus: Wiederholung des ganzen Tastenfelds.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)(&)&[&]&{&}&<&> - Ubung 1
+D:() [] {} <> () [] {} <> () [] {} <> () [] {} <> () [] {} <>
+I:(2)1&+&2&=&3&; - Ubung 2
+D:1 + 2 = 3; 1 + 2 = 3; 1 + 2 = 3; 1 + 2 = 3; 1 + 2 = 3; 1 + 2 = 3;
+I:(3)r&e&c&o&d&[&a&w&n&]&=&{ - Ubung 3
+D:record [dawn] = {clear} + "focus"
+
+G:DAWN_CITADEL
+
+*:DAY_81
+B:KeyQuest - Tag 81 - Dawn Citadel: Phrase Review
+T:Tag 81 guidance.
+ :Bogen: Dawn Citadel. Wiederholung des ganzen Tastenfelds.
+ :Fokus: Wiederholung des ganzen Tastenfelds.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)t&h&e&d&a&w&n&c&i&l&g&r - Ubung 1
+D:the dawn citadel gathers every lesson into one path
+I:(2)s&t&e&a&d&y&r&h&m&c&i&l - Ubung 2
+D:steady rhythm carries letters, numbers, and marks
+I:(3)f&u&l&m&a&s&t&e&r&y&b&g - Ubung 3
+D:full mastery begins with one clean line at a time
+
+G:DAWN_CITADEL
+
+*:DAY_82
+B:KeyQuest - Tag 82 - Dawn Citadel: Recovery Review
+T:Tag 82 guidance.
+ :Bogen: Dawn Citadel. Wiederholung des ganzen Tastenfelds.
+ :Fokus: Wiederholung des ganzen Tastenfelds.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)q&z&p&;&v&b&n&m - Ubung 1
+D:q z p ; v b n m q z p ; v b n m q z p ; v b n m q z p ; v b n m
+I:(2)r&e&c&o&v&[&q&u&i&t&l&y - Ubung 2
+D:recover [quietly] after {difficult} symbols
+I:(3)t&h&e&c&i&a&d&l&r&w&s&m - Ubung 3
+D:the citadel rewards calm correction
+
+G:DAWN_CITADEL
+
+*:DAY_83
+B:KeyQuest - Tag 83 - Dawn Citadel: Final Review
+T:Tag 83 guidance.
+ :Bogen: Dawn Citadel. Wiederholung des ganzen Tastenfelds.
+ :Fokus: Wiederholung des ganzen Tastenfelds.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)G&a&t&e&8&3&o&p&n&s&w&h - Ubung 1
+D:Gate 83 opens when "focus" stays bright.
+I:(2)D&a&w&n&l&i&g&h&t&c&r&o - Ubung 2
+D:Dawn light crosses room 12, hall 34, and tower 56.
+I:(3)t&y&p&e&s&l&o&w&n&u&g&h - Ubung 3
+D:type slowly enough to finish cleanly
+
+G:DAWN_CITADEL
+
+*:DAY_84
+B:KeyQuest - Tag 84 - Dawn Citadel: Dawn Trial
+T:Tag 84 guidance.
+ :Bogen: Dawn Citadel. Wiederholung des ganzen Tastenfelds.
+ :Fokus: Wiederholung des ganzen Tastenfelds.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)q&w&e&r&a&s&d&f&z&x&c&v - Ubung 1
+D:qwer asdf zxcv uiop qwer asdf zxcv uiop qwer asdf zxcv uiop
+I:(2)D&a&w&n&C&i&t&d&e&l&:&[ - Ubung 2
+D:Dawn Citadel: [ready] = {calm} + "accuracy"
+I:(3)E&v&e&r&y&o&w&,&n&u&m&b - Ubung 3
+D:Every row, number, and mark returns home.
+I:(4)T&h&e&f&i&n&a&l&g&t&p&r - Ubung 4
+D:The final gate appears in the morning light.
+
+G:DAWN_CITADEL
+
+*:DAY_85
+B:KeyQuest - Tag 85 - Final Gate: First Seal
+T:Tag 85 guidance.
+ :Bogen: Final Gate. letzte integrierte Tippquest.
+ :Fokus: letzte integrierte Tippquest.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)a&s&d&f&q&w&e&r&z&x&c&v - Ubung 1
+D:asdf qwer zxcv 1234 asdf qwer zxcv 1234 asdf qwer zxcv 1234
+I:(2)T&h&e&f&i&r&s&t&a&l&o&p - Ubung 2
+D:The first seal opens for calm accurate hands.
+I:(3)R&e&v&i&w&r&y&o&b&f&t&h - Ubung 3
+D:Review every row before the final spell begins.
+I:(4)s&t&e&a&d&y&f&o&c&u&r&i - Ubung 4
+D:steady focus carries the key toward silence
+
+G:FINAL_GATE
+
+*:DAY_86
+B:KeyQuest - Tag 86 - Final Gate: Second Seal
+T:Tag 86 guidance.
+ :Bogen: Final Gate. letzte integrierte Tippquest.
+ :Fokus: letzte integrierte Tippquest.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)S&e&a&l&2&:&"&H&o&d&f&c - Ubung 1
+D:Seal 2: "Hold focus," says the old gate.
+I:(2)K&e&y&8&6&t&u&r&n&s&l&o - Ubung 2
+D:Key 86 turns slowly; the path remains clear.
+I:(3)A&B&r&i&g&h&t&H&a&n&d&y - Ubung 3
+D:A Bright Hand types 3 clean lines before dawn.
+I:(4)n&u&m&b&e&r&s&a&d&k&o&y - Ubung 4
+D:numbers and marks obey patient fingers
+
+G:FINAL_GATE
+
+*:DAY_87
+B:KeyQuest - Tag 87 - Final Gate: Third Seal
+T:Tag 87 guidance.
+ :Bogen: Final Gate. letzte integrierte Tippquest.
+ :Fokus: letzte integrierte Tippquest.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)i&f&g&a&t&e&=&o&p&n&h&l - Ubung 1
+D:if gate = open then hold steady focus
+I:(2)f&i&n&a&l&[&s&e&]&=&{&c - Ubung 2
+D:final[seal] = {calm} + "accuracy"
+I:(3)p&a&t&h&/&k&e&y&l&i&g&d - Ubung 3
+D:path / key / light leads beyond silence
+I:(4)p&a&i&r&e&d&s&y&m&b&o&l - Ubung 4
+D:paired symbols guard the third seal
+
+G:FINAL_GATE
+
+*:DAY_88
+B:KeyQuest - Tag 88 - Final Gate: Fourth Seal
+T:Tag 88 guidance.
+ :Bogen: Final Gate. letzte integrierte Tippquest.
+ :Fokus: letzte integrierte Tippquest.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)T&h&e&L&o&r&d&f&S&i&l&n - Ubung 1
+D:The Lord of Silence waits beyond the final gate.
+I:(2)E&v&e&r&y&l&s&o&n&t&u&a - Ubung 2
+D:Every lesson returns as one quiet line of light.
+I:(3)D&o&n&t&r&u&s&h&e&d&i&g - Ubung 3
+D:Do not rush the ending; complete it cleanly.
+I:(4)a&c&u&r&y&t&n&s&h&e&l&d - Ubung 4
+D:accuracy turns the last shadow into dawn
+
+G:FINAL_GATE
+
+*:DAY_89
+B:KeyQuest - Tag 89 - Final Gate: Last Camp
+T:Tag 89 guidance.
+ :Bogen: Final Gate. letzte integrierte Tippquest.
+ :Fokus: letzte integrierte Tippquest.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)N&o&v&i&c&e&h&a&n&d&s&b - Ubung 1
+D:Novice hands became steady hands over many days.
+I:(2)R&o&w&s&,&n&u&m&b&e&r&y - Ubung 2
+D:Rows, numbers, symbols, and stories gather here.
+I:(3)B&r&e&a&t&h&o&n&c&b&f&i - Ubung 3
+D:Breathe once before the final spell is typed.
+I:(4)t&h&e&l&a&s&c&m&p&i&q&u - Ubung 4
+D:the last camp is quiet, bright, and ready
+
+G:FINAL_GATE
+
+*:DAY_90
+B:KeyQuest - Tag 90 - Final Gate: Last Spell Trial
+T:Tag 90 guidance.
+ :Bogen: Final Gate. letzte integrierte Tippquest.
+ :Fokus: letzte integrierte Tippquest.
+ :Setze Genauigkeit zuerst; Tempo kommt erst nach einer sauberen Zeile.
+I:(1)T&h&e&f&i&n&a&l&g&t&o&p - Ubung 1
+D:The final gate opens when every key returns home.
+I:(2)K&e&y&Q&u&s&t&D&a&9&0&: - Ubung 2
+D:KeyQuest Day 90: "Accuracy breaks the silence."
+I:(3)i&f&o&c&u&s&=&t&e&a&d&y - Ubung 3
+D:if focus = steady then the last spell shines
+I:(4)T&h&e&L&o&r&d&f&S&i&l&n - Ubung 4
+D:The Lord of Silence falls to calm typing.
+
+G:FINAL_GATE
+
+*:ABOUT
+B:Uber das KeyQuest Tippabenteuer
+T:Dieses GNU Typist Skript macht KeyQuest zu einem 90 Tage Tippabenteuer.
+ :Die D: Tippzeilen bleiben englisch und sind in allen Sprachen identisch.
+ :Nur Menus, Titel und Erklarungen werden lokalisiert.
+ :Ube einen Tag pro Sitzung und wiederhole, wenn die Genauigkeit sinkt.
+G:MENU
+*:EXIT
+B:Danke fur dein Training mit KeyQuest.
+T:Ube jeden Tag ein wenig. Genauigkeit offnet das letzte Tor.
+X:

--- a/keyquest.es.typ
+++ b/keyquest.es.typ
@@ -1,0 +1,1590 @@
+*:MENU
+M: "Viaje de mecanografia KeyQuest"
+ :NOVICE_HALL  "Novice Hall"
+ :MEADOW_ROAD  "Meadow Road"
+ :RIVER_GATE  "River Gate"
+ :LANTERN_KEEP  "Lantern Keep"
+ :ASHEN_FORGE  "Ashen Forge"
+ :WINDSPIRE  "Windspire"
+ :CLOCKWORK_CITADEL  "Clockwork Citadel"
+ :STARFALL_LIBRARY  "Starfall Library"
+ :DRAGON_SPINE  "Dragon Spine"
+ :MOONLIT_LABYRINTH  "Moonlit Labyrinth"
+ :OBSIDIAN_THRONE  "Obsidian Throne"
+ :DAWN_CITADEL  "Dawn Citadel"
+ :FINAL_GATE  "Final Gate"
+ :ABOUT  "Acerca de este script"
+ :EXIT  "Salir"
+
+*:NOVICE_HALL
+M: "Novice Hall"
+ :DAY_01  "Dia 01: Home Position"
+ :DAY_02  "Dia 02: Left And Right Balance"
+ :DAY_03  "Dia 03: Finger Responsibility"
+ :DAY_04  "Dia 04: Rhythm Hall"
+ :DAY_05  "Dia 05: First Words"
+ :DAY_06  "Dia 06: Repair The Stance"
+ :DAY_07  "Dia 07: Gatekeeper Trial"
+ :MENU  "Volver al menu del arco"
+
+*:MEADOW_ROAD
+M: "Meadow Road"
+ :DAY_08  "Dia 08: First Steps Beyond Home"
+ :DAY_09  "Dia 09: Ring Finger Reach"
+ :DAY_10  "Dia 10: Index Reach"
+ :DAY_11  "Dia 11: Outer Watch"
+ :DAY_12  "Dia 12: Top Row Trail"
+ :DAY_13  "Dia 13: First Flow"
+ :DAY_14  "Dia 14: Waystone Trial"
+ :MENU  "Volver al menu del arco"
+
+*:RIVER_GATE
+M: "River Gate"
+ :DAY_15  "Dia 15: Lower Step"
+ :DAY_16  "Dia 16: Valley Reach"
+ :DAY_17  "Dia 17: Bridge Keys"
+ :DAY_18  "Dia 18: Comma And Period"
+ :DAY_19  "Dia 19: Bottom Row Words"
+ :DAY_20  "Dia 20: Current Review"
+ :DAY_21  "Dia 21: Ferryman Trial"
+ :MENU  "Volver al menu del arco"
+
+*:LANTERN_KEEP
+M: "Lantern Keep"
+ :DAY_22  "Dia 22: Left Number Row"
+ :DAY_23  "Dia 23: Right Number Row"
+ :DAY_24  "Dia 24: Center Span"
+ :DAY_25  "Dia 25: Counts And Codes"
+ :DAY_26  "Dia 26: Map Marks"
+ :DAY_27  "Dia 27: Mixed Signals"
+ :DAY_28  "Dia 28: Beacon Trial"
+ :MENU  "Volver al menu del arco"
+
+*:ASHEN_FORGE
+M: "Ashen Forge"
+ :DAY_29  "Dia 29: Left Shift Spark"
+ :DAY_30  "Dia 30: Right Shift Spark"
+ :DAY_31  "Dia 31: Capital Names"
+ :DAY_32  "Dia 32: Sentence Starts"
+ :DAY_33  "Dia 33: Title Case"
+ :DAY_34  "Dia 34: Shift Review"
+ :DAY_35  "Dia 35: Anvil Trial"
+ :MENU  "Volver al menu del arco"
+
+*:WINDSPIRE
+M: "Windspire"
+ :DAY_36  "Dia 36: Even Steps"
+ :DAY_37  "Dia 37: Short Bursts"
+ :DAY_38  "Dia 38: Long Cadence"
+ :DAY_39  "Dia 39: Alternate Pace"
+ :DAY_40  "Dia 40: Breath Marks"
+ :DAY_41  "Dia 41: Gale Review"
+ :DAY_42  "Dia 42: Gale Trial"
+ :MENU  "Volver al menu del arco"
+
+*:CLOCKWORK_CITADEL
+M: "Clockwork Citadel"
+ :DAY_43  "Dia 43: Parentheses"
+ :DAY_44  "Dia 44: Brackets"
+ :DAY_45  "Dia 45: Braces"
+ :DAY_46  "Dia 46: Angle Gates"
+ :DAY_47  "Dia 47: Nested Pairs"
+ :DAY_48  "Dia 48: Gear Review"
+ :DAY_49  "Dia 49: Gearheart Trial"
+ :MENU  "Volver al menu del arco"
+
+*:STARFALL_LIBRARY
+M: "Starfall Library"
+ :DAY_50  "Dia 50: Math Signs"
+ :DAY_51  "Dia 51: Slash And Star"
+ :DAY_52  "Dia 52: Quotes"
+ :DAY_53  "Dia 53: Colon Signals"
+ :DAY_54  "Dia 54: Code Words"
+ :DAY_55  "Dia 55: Archive Review"
+ :DAY_56  "Dia 56: Archivist Trial"
+ :MENU  "Volver al menu del arco"
+
+*:DRAGON_SPINE
+M: "Dragon Spine"
+ :DAY_57  "Dia 57: Pressure Warmup"
+ :DAY_58  "Dia 58: Longer Climb"
+ :DAY_59  "Dia 59: Heat Control"
+ :DAY_60  "Dia 60: No Panic"
+ :DAY_61  "Dia 61: Focus Run"
+ :DAY_62  "Dia 62: Wyrm Review"
+ :DAY_63  "Dia 63: Wyrm Trial"
+ :MENU  "Volver al menu del arco"
+
+*:MOONLIT_LABYRINTH
+M: "Moonlit Labyrinth"
+ :DAY_64  "Dia 64: Slow Repair"
+ :DAY_65  "Dia 65: Outer Keys"
+ :DAY_66  "Dia 66: Bottom Repair"
+ :DAY_67  "Dia 67: Symbol Repair"
+ :DAY_68  "Dia 68: Mirror Paths"
+ :DAY_69  "Dia 69: Labyrinth Review"
+ :DAY_70  "Dia 70: Minotaur Trial"
+ :MENU  "Volver al menu del arco"
+
+*:OBSIDIAN_THRONE
+M: "Obsidian Throne"
+ :DAY_71  "Dia 71: Mixed Marks"
+ :DAY_72  "Dia 72: Quote Orders"
+ :DAY_73  "Dia 73: Long Focus"
+ :DAY_74  "Dia 74: Clause Chains"
+ :DAY_75  "Dia 75: Dense Review"
+ :DAY_76  "Dia 76: Crown Approach"
+ :DAY_77  "Dia 77: Crown Trial"
+ :MENU  "Volver al menu del arco"
+
+*:DAWN_CITADEL
+M: "Dawn Citadel"
+ :DAY_78  "Dia 78: Full Keyboard Scan"
+ :DAY_79  "Dia 79: Capital Review"
+ :DAY_80  "Dia 80: Symbol Review"
+ :DAY_81  "Dia 81: Phrase Review"
+ :DAY_82  "Dia 82: Recovery Review"
+ :DAY_83  "Dia 83: Final Review"
+ :DAY_84  "Dia 84: Dawn Trial"
+ :MENU  "Volver al menu del arco"
+
+*:FINAL_GATE
+M: "Final Gate"
+ :DAY_85  "Dia 85: First Seal"
+ :DAY_86  "Dia 86: Second Seal"
+ :DAY_87  "Dia 87: Third Seal"
+ :DAY_88  "Dia 88: Fourth Seal"
+ :DAY_89  "Dia 89: Last Camp"
+ :DAY_90  "Dia 90: Last Spell Trial"
+ :MENU  "Volver al menu del arco"
+
+*:DAY_01
+B:KeyQuest - Dia 01 - Novice Hall: Home Position
+T:Dia 01 guidance.
+ :Arco: Novice Hall. postura base y responsabilidad de los dedos.
+ :Enfoque: postura base y responsabilidad de los dedos.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)f&j - ejercicio 1
+D:f j f j f j f j f j f j f j f j
+I:(2)f&j - ejercicio 2
+D:ff jj ff jj ff jj ff jj ff jj ff jj ff jj ff jj
+I:(3)f&j - ejercicio 3
+D:fj jf fj jf fj jf fj jf fj jf fj jf fj jf fj jf
+I:(4)a&s&d&f&j&k&l&; - ejercicio 4
+D:asdf jkl; asdf jkl; asdf jkl; asdf jkl; asdf jkl; asdf jkl;
+
+G:NOVICE_HALL
+
+*:DAY_02
+B:KeyQuest - Dia 02 - Novice Hall: Left And Right Balance
+T:Dia 02 guidance.
+ :Arco: Novice Hall. postura base y responsabilidad de los dedos.
+ :Enfoque: postura base y responsabilidad de los dedos.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)a&s&d&f&j&k&l&; - ejercicio 1
+D:asdf jkl; asdf jkl; asdf jkl; asdf jkl; asdf jkl; asdf jkl;
+I:(2)a&s&d&f&j&k&l&; - ejercicio 2
+D:asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj
+I:(3)a&f&s&j&d&k&l - ejercicio 3
+D:af sj dk fl af sj dk fl af sj dk fl af sj dk fl af sj dk fl
+I:(4)a&s&d&f&j&k&l - ejercicio 4
+D:sad lad ask fall sad lad ask fall sad lad ask fall sad lad ask fall
+
+G:NOVICE_HALL
+
+*:DAY_03
+B:KeyQuest - Dia 03 - Novice Hall: Finger Responsibility
+T:Dia 03 guidance.
+ :Arco: Novice Hall. postura base y responsabilidad de los dedos.
+ :Enfoque: postura base y responsabilidad de los dedos.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)a&s&d&f&j&k&l&; - ejercicio 1
+D:aa ss dd ff jj kk ll ;; aa ss dd ff jj kk ll ;;
+I:(2)a&s&d&f&j&k&l&; - ejercicio 2
+D:as df jk l; as df jk l; as df jk l; as df jk l; as df jk l;
+I:(3)a&;&s&l&d&k&f&j - ejercicio 3
+D:a; sl dk fj a; sl dk fj a; sl dk fj a; sl dk fj a; sl dk fj
+I:(4)a&s&d&f&j&k&l - ejercicio 4
+D:ask sad fall flask ask sad fall flask ask sad fall flask
+
+G:NOVICE_HALL
+
+*:DAY_04
+B:KeyQuest - Dia 04 - Novice Hall: Rhythm Hall
+T:Dia 04 guidance.
+ :Arco: Novice Hall. postura base y responsabilidad de los dedos.
+ :Enfoque: postura base y responsabilidad de los dedos.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)a&s&d&f&j&k&l&; - ejercicio 1
+D:asdf asdf jkl; jkl; asdf asdf jkl; jkl; asdf asdf jkl; jkl;
+I:(2)f&d&s&a&;&l&k&j - ejercicio 2
+D:fdsa fdsa ;lkj ;lkj fdsa fdsa ;lkj ;lkj fdsa fdsa ;lkj ;lkj
+I:(3)a&s&d&f&j&k&l&; - ejercicio 3
+D:asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj
+I:(4)a&s&d&f&j&k&l - ejercicio 4
+D:ask fall sad flask ask fall sad flask ask fall sad flask
+
+G:NOVICE_HALL
+
+*:DAY_05
+B:KeyQuest - Dia 05 - Novice Hall: First Words
+T:Dia 05 guidance.
+ :Arco: Novice Hall. postura base y responsabilidad de los dedos.
+ :Enfoque: postura base y responsabilidad de los dedos.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)a&s&d&l&k - ejercicio 1
+D:ask sad lad ask sad lad ask sad lad ask sad lad ask sad lad
+I:(2)f&a&l&s&k - ejercicio 2
+D:fall flask fall flask fall flask fall flask fall flask fall flask
+I:(3)d&a&f&s&l - ejercicio 3
+D:dad fad salad dad fad salad dad fad salad dad fad salad
+I:(4)a&s&k&l&d&f - ejercicio 4
+D:ask lad fall flask ask lad fall flask ask lad fall flask
+
+G:NOVICE_HALL
+
+*:DAY_06
+B:KeyQuest - Dia 06 - Novice Hall: Repair The Stance
+T:Dia 06 guidance.
+ :Arco: Novice Hall. postura base y responsabilidad de los dedos.
+ :Enfoque: postura base y responsabilidad de los dedos.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)a&;&s&l - ejercicio 1
+D:aa ;; ss ll aa ;; ss ll aa ;; ss ll aa ;; ss ll aa ;; ss ll
+I:(2)a&;&s&l - ejercicio 2
+D:a; s; al sl a; s; al sl a; s; al sl a; s; al sl a; s; al sl
+I:(3)s&a&d&l&f - ejercicio 3
+D:sad lass fall sad lass fall sad lass fall sad lass fall
+I:(4)a&s&k&l&f&d - ejercicio 4
+D:ask lass fall salad ask lass fall salad ask lass fall salad
+
+G:NOVICE_HALL
+
+*:DAY_07
+B:KeyQuest - Dia 07 - Novice Hall: Gatekeeper Trial
+T:Dia 07 guidance.
+ :Arco: Novice Hall. postura base y responsabilidad de los dedos.
+ :Enfoque: postura base y responsabilidad de los dedos.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)f&j&a&s&d&k&l&; - ejercicio 1
+D:f j as df jk l; f j as df jk l; f j as df jk l; f j as df jk l;
+I:(2)a&s&d&f&j&k&l&; - ejercicio 2
+D:asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj
+I:(3)a&s&k&d&l&f - ejercicio 3
+D:ask sad lad fall ask sad lad fall ask sad lad fall ask sad lad fall
+I:(4)a&s&k&l&f&d - ejercicio 4
+D:ask lass fall salad flask ask lass fall salad flask
+
+G:NOVICE_HALL
+
+*:DAY_08
+B:KeyQuest - Dia 08 - Meadow Road: First Steps Beyond Home
+T:Dia 08 guidance.
+ :Arco: Meadow Road. alcance a la fila superior con regreso a base.
+ :Enfoque: alcance a la fila superior con regreso a base.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)f&r&j&u - ejercicio 1
+D:fr ju fr ju fr ju fr ju fr ju fr ju fr ju fr ju fr ju fr ju
+I:(2)d&e&k&i - ejercicio 2
+D:de ki de ki de ki de ki de ki de ki de ki de ki de ki de ki
+I:(3)r&e&d&k&i - ejercicio 3
+D:red kid ride red kid ride red kid ride red kid ride red kid ride
+I:(4)r&u&d&e&i - ejercicio 4
+D:rude deer ride rude deer ride rude deer ride rude deer ride
+
+G:MEADOW_ROAD
+
+*:DAY_09
+B:KeyQuest - Dia 09 - Meadow Road: Ring Finger Reach
+T:Dia 09 guidance.
+ :Arco: Meadow Road. alcance a la fila superior con regreso a base.
+ :Enfoque: alcance a la fila superior con regreso a base.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)s&w&l&o - ejercicio 1
+D:sw lo sw lo sw lo sw lo sw lo sw lo sw lo sw lo sw lo sw lo
+I:(2)w&e&o&l&d - ejercicio 2
+D:we old we old we old we old we old we old we old we old
+I:(3)s&l&o&w - ejercicio 3
+D:slow low owl slow low owl slow low owl slow low owl slow low owl
+I:(4)o&l&d&w&s - ejercicio 4
+D:old owl slow old owl slow old owl slow old owl slow old owl slow
+
+G:MEADOW_ROAD
+
+*:DAY_10
+B:KeyQuest - Dia 10 - Meadow Road: Index Reach
+T:Dia 10 guidance.
+ :Arco: Meadow Road. alcance a la fila superior con regreso a base.
+ :Enfoque: alcance a la fila superior con regreso a base.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)f&t&j&y - ejercicio 1
+D:ft jy ft jy ft jy ft jy ft jy ft jy ft jy ft jy ft jy ft jy
+I:(2)t&r&y&e - ejercicio 2
+D:try yet try yet try yet try yet try yet try yet try yet try yet
+I:(3)d&r&y&t&a - ejercicio 3
+D:dry try yard dry try yard dry try yard dry try yard dry try yard
+I:(4)s&t&a&y&r&e&d - ejercicio 4
+D:stay ready steady stay ready steady stay ready steady
+
+G:MEADOW_ROAD
+
+*:DAY_11
+B:KeyQuest - Dia 11 - Meadow Road: Outer Watch
+T:Dia 11 guidance.
+ :Arco: Meadow Road. alcance a la fila superior con regreso a base.
+ :Enfoque: alcance a la fila superior con regreso a base.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)a&q&;&p - ejercicio 1
+D:aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p
+I:(2)q&u&i&c&k&e&t - ejercicio 2
+D:quick quiet quick quiet quick quiet quick quiet quick quiet
+I:(3)p&o&i&e&u - ejercicio 3
+D:pop pipe pup pop pipe pup pop pipe pup pop pipe pup pop pipe pup
+I:(4)q&u&i&p&c&k&o - ejercicio 4
+D:quip quick pop quip quick pop quip quick pop quip quick pop
+
+G:MEADOW_ROAD
+
+*:DAY_12
+B:KeyQuest - Dia 12 - Meadow Road: Top Row Trail
+T:Dia 12 guidance.
+ :Arco: Meadow Road. alcance a la fila superior con regreso a base.
+ :Enfoque: alcance a la fila superior con regreso a base.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)q&w&e&r&u&i&o&p - ejercicio 1
+D:qwer uiop qwer uiop qwer uiop qwer uiop qwer uiop qwer uiop
+I:(2)t&r&e&w&p&o&i - ejercicio 2
+D:trew poi poi trew trew poi poi trew trew poi poi trew
+I:(3)w&e&q&u&i&t&p&o - ejercicio 3
+D:we quit we pop we quit we pop we quit we pop we quit we pop
+I:(4)t&y&p&e&u&r&q&i - ejercicio 4
+D:type pure quiet type pure quiet type pure quiet type pure quiet
+
+G:MEADOW_ROAD
+
+*:DAY_13
+B:KeyQuest - Dia 13 - Meadow Road: First Flow
+T:Dia 13 guidance.
+ :Arco: Meadow Road. alcance a la fila superior con regreso a base.
+ :Enfoque: alcance a la fila superior con regreso a base.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)q&u&i&e&t&r&d - ejercicio 1
+D:quiet rider quiet rider quiet rider quiet rider quiet rider
+I:(2)t&y&p&e&o&u&r&s - ejercicio 2
+D:type your story type your story type your story type your story
+I:(3)w&e&t&r&y&q&u&i&o&k - ejercicio 3
+D:we try quiet work we try quiet work we try quiet work
+I:(4)s&t&e&a&d&y&h&n&p&r&u - ejercicio 4
+D:steady hands type true steady hands type true
+
+G:MEADOW_ROAD
+
+*:DAY_14
+B:KeyQuest - Dia 14 - Meadow Road: Waystone Trial
+T:Dia 14 guidance.
+ :Arco: Meadow Road. alcance a la fila superior con regreso a base.
+ :Enfoque: alcance a la fila superior con regreso a base.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)q&w&e&r&u&i&o&p&a&s&d&f - ejercicio 1
+D:qwer uiop asdf jkl; qwer uiop asdf jkl; qwer uiop asdf jkl;
+I:(2)q&u&i&e&t&y&p&r&w&o&k - ejercicio 2
+D:quiet type pure work quiet type pure work quiet type pure work
+I:(3)s&t&e&a&d&y&q&u&i&r - ejercicio 3
+D:steady quiet rider steady quiet rider steady quiet rider
+I:(4)y&o&u&r&q&i&e&t&s&a&d&h - ejercicio 4
+D:your quiet steady hands type true your quiet steady hands type true
+
+G:MEADOW_ROAD
+
+*:DAY_15
+B:KeyQuest - Dia 15 - River Gate: Lower Step
+T:Dia 15 guidance.
+ :Arco: River Gate. fila inferior, teclas puente y puntuacion.
+ :Enfoque: fila inferior, teclas puente y puntuacion.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)d&c&k&m - ejercicio 1
+D:dc km dc km dc km dc km dc km dc km dc km dc km dc km dc km
+I:(2)c&o&m&e&a&l - ejercicio 2
+D:come calm come calm come calm come calm come calm come calm
+I:(3)m&a&k&e&c&l&o&v&s - ejercicio 3
+D:make calm moves make calm moves make calm moves make calm moves
+
+G:RIVER_GATE
+
+*:DAY_16
+B:KeyQuest - Dia 16 - River Gate: Valley Reach
+T:Dia 16 guidance.
+ :Arco: River Gate. fila inferior, teclas puente y puntuacion.
+ :Enfoque: fila inferior, teclas puente y puntuacion.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)f&v&j&n - ejercicio 1
+D:fv jn fv jn fv jn fv jn fv jn fv jn fv jn fv jn fv jn fv jn
+I:(2)e&v&n&i - ejercicio 2
+D:even nine even nine even nine even nine even nine even nine
+I:(3)m&o&v&e&n&r&a&i&s&h - ejercicio 3
+D:move never vanish move never vanish move never vanish
+
+G:RIVER_GATE
+
+*:DAY_17
+B:KeyQuest - Dia 17 - River Gate: Bridge Keys
+T:Dia 17 guidance.
+ :Arco: River Gate. fila inferior, teclas puente y puntuacion.
+ :Enfoque: fila inferior, teclas puente y puntuacion.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)f&g&j&h&b&n - ejercicio 1
+D:fg jh fb jn fg jh fb jn fg jh fb jn fg jh fb jn fg jh fb jn
+I:(2)b&r&i&n&g&h&t - ejercicio 2
+D:bring bright bring bright bring bright bring bright
+I:(3)b&e&g&i&n&t&h&r&d - ejercicio 3
+D:begin the bridge begin the bridge begin the bridge begin the bridge
+
+G:RIVER_GATE
+
+*:DAY_18
+B:KeyQuest - Dia 18 - River Gate: Comma And Period
+T:Dia 18 guidance.
+ :Arco: River Gate. fila inferior, teclas puente y puntuacion.
+ :Enfoque: fila inferior, teclas puente y puntuacion.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)k&,&l&. - ejercicio 1
+D:k, l. k, l. k, l. k, l. k, l. k, l. k, l. k, l. k, l. k, l.
+I:(2)c&a&l&m&,&s&t&e&d&y&. - ejercicio 2
+D:calm, steady. calm, steady. calm, steady. calm, steady.
+I:(3)m&o&v&e&,&r&s&t&. - ejercicio 3
+D:move, rest. move, rest. move, rest. move, rest.
+
+G:RIVER_GATE
+
+*:DAY_19
+B:KeyQuest - Dia 19 - River Gate: Bottom Row Words
+T:Dia 19 guidance.
+ :Arco: River Gate. fila inferior, teclas puente y puntuacion.
+ :Enfoque: fila inferior, teclas puente y puntuacion.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)b&r&a&v&e&m&o&c&l - ejercicio 1
+D:brave move calm brave move calm brave move calm brave move calm
+I:(2)n&e&v&r&b&i&g&p&a&c - ejercicio 2
+D:never bring panic never bring panic never bring panic
+I:(3)s&t&e&a&d&y&r&i&v&,&b&h - ejercicio 3
+D:steady river, brave hands. steady river, brave hands.
+
+G:RIVER_GATE
+
+*:DAY_20
+B:KeyQuest - Dia 20 - River Gate: Current Review
+T:Dia 20 guidance.
+ :Arco: River Gate. fila inferior, teclas puente y puntuacion.
+ :Enfoque: fila inferior, teclas puente y puntuacion.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)q&w&e&r&a&s&d&f&z&x&c&v - ejercicio 1
+D:qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv
+I:(2)u&i&o&p&j&k&l&;&n&m&,&. - ejercicio 2
+D:uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,.
+I:(3)b&r&i&n&g&c&a&l&m&,&o&v - ejercicio 3
+D:bring calm, move steady. bring calm, move steady.
+
+G:RIVER_GATE
+
+*:DAY_21
+B:KeyQuest - Dia 21 - River Gate: Ferryman Trial
+T:Dia 21 guidance.
+ :Arco: River Gate. fila inferior, teclas puente y puntuacion.
+ :Enfoque: fila inferior, teclas puente y puntuacion.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)a&s&d&f&q&w&e&r&z&x&c&v - ejercicio 1
+D:asdf qwer zxcv asdf qwer zxcv asdf qwer zxcv asdf qwer zxcv
+I:(2)j&k&l&;&u&i&o&p&n&m&,&. - ejercicio 2
+D:jkl; uiop nm,. jkl; uiop nm,. jkl; uiop nm,. jkl; uiop nm,.
+I:(3)n&e&v&r&p&a&i&c&,&m&o&s - ejercicio 3
+D:never panic, move steady. never panic, move steady.
+I:(4)b&r&a&v&e&h&n&d&s&c&o&t - ejercicio 4
+D:brave hands cross the quiet river. brave hands cross the quiet river.
+
+G:RIVER_GATE
+
+*:DAY_22
+B:KeyQuest - Dia 22 - Lantern Keep: Left Number Row
+T:Dia 22 guidance.
+ :Arco: Lantern Keep. fila numerica y numeros practicos.
+ :Enfoque: fila numerica y numeros practicos.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)1&2&3&4 - ejercicio 1
+D:1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4
+I:(2)1&2&3&4 - ejercicio 2
+D:11 22 33 44 11 22 33 44 11 22 33 44 11 22 33 44 11 22 33 44
+I:(3)r&o&m&1&2&g&a&t&e&3&4 - ejercicio 3
+D:room 12 gate 34 room 12 gate 34 room 12 gate 34 room 12 gate 34
+
+G:LANTERN_KEEP
+
+*:DAY_23
+B:KeyQuest - Dia 23 - Lantern Keep: Right Number Row
+T:Dia 23 guidance.
+ :Arco: Lantern Keep. fila numerica y numeros practicos.
+ :Enfoque: fila numerica y numeros practicos.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)7&8&9&0 - ejercicio 1
+D:7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0
+I:(2)7&8&9&0 - ejercicio 2
+D:77 88 99 00 77 88 99 00 77 88 99 00 77 88 99 00 77 88 99 00
+I:(3)t&o&w&e&r&7&8&p&a&h&9&0 - ejercicio 3
+D:tower 78 path 90 tower 78 path 90 tower 78 path 90 tower 78 path 90
+
+G:LANTERN_KEEP
+
+*:DAY_24
+B:KeyQuest - Dia 24 - Lantern Keep: Center Span
+T:Dia 24 guidance.
+ :Arco: Lantern Keep. fila numerica y numeros practicos.
+ :Enfoque: fila numerica y numeros practicos.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)4&5&6&7 - ejercicio 1
+D:4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7
+I:(2)4&5&6&7 - ejercicio 2
+D:45 56 67 76 65 54 45 56 67 76 65 54 45 56 67 76 65 54
+I:(3)l&e&v&4&5&b&r&i&d&g&6&7 - ejercicio 3
+D:level 45 bridge 67 level 45 bridge 67 level 45 bridge 67
+
+G:LANTERN_KEEP
+
+*:DAY_25
+B:KeyQuest - Dia 25 - Lantern Keep: Counts And Codes
+T:Dia 25 guidance.
+ :Arco: Lantern Keep. fila numerica y numeros practicos.
+ :Enfoque: fila numerica y numeros practicos.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)t&a&k&e&2&y&s&3&m&p - ejercicio 1
+D:take 2 keys and 3 maps take 2 keys and 3 maps
+I:(2)m&a&r&k&4&o&s&b&e&f&5 - ejercicio 2
+D:mark 4 rooms before 5 mark 4 rooms before 5 mark 4 rooms before 5
+I:(3)c&o&d&e&1&2&0&p&n&s&g&a - ejercicio 3
+D:code 120 opens gate 34 code 120 opens gate 34
+
+G:LANTERN_KEEP
+
+*:DAY_26
+B:KeyQuest - Dia 26 - Lantern Keep: Map Marks
+T:Dia 26 guidance.
+ :Arco: Lantern Keep. fila numerica y numeros practicos.
+ :Enfoque: fila numerica y numeros practicos.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)m&a&p&1&r&o&2&h&l&3 - ejercicio 1
+D:map 1 room 2 hall 3 map 1 room 2 hall 3 map 1 room 2 hall 3
+I:(2)t&u&r&n&6&h&e&o&p&7 - ejercicio 2
+D:turn 6 then open 7 turn 6 then open 7 turn 6 then open 7
+I:(3)l&a&m&p&8&s&h&o&w&d&r&9 - ejercicio 3
+D:lamp 8 shows door 9 lamp 8 shows door 9 lamp 8 shows door 9
+
+G:LANTERN_KEEP
+
+*:DAY_27
+B:KeyQuest - Dia 27 - Lantern Keep: Mixed Signals
+T:Dia 27 guidance.
+ :Arco: Lantern Keep. fila numerica y numeros practicos.
+ :Enfoque: fila numerica y numeros practicos.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)l&e&v&2&m&a&p&4&g&t&6 - ejercicio 1
+D:level 2 map 4 gate 6 level 2 map 4 gate 6 level 2 map 4 gate 6
+I:(2)p&a&t&h&8&r&o&m&1&0 - ejercicio 2
+D:path 8 room 10 path 8 room 10 path 8 room 10 path 8 room 10
+I:(3)s&t&e&a&d&y&h&n&r&i&g&l - ejercicio 3
+D:steady hands read signal 27 steady hands read signal 27
+
+G:LANTERN_KEEP
+
+*:DAY_28
+B:KeyQuest - Dia 28 - Lantern Keep: Beacon Trial
+T:Dia 28 guidance.
+ :Arco: Lantern Keep. fila numerica y numeros practicos.
+ :Enfoque: fila numerica y numeros practicos.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)1&2&3&4&5&6&7&8&9&0 - ejercicio 1
+D:1234 567 890 1234 567 890 1234 567 890 1234 567 890 1234 567 890
+I:(2)g&a&t&e&1&2&r&o&m&3&4&p - ejercicio 2
+D:gate 12 room 34 path 56 gate 12 room 34 path 56
+I:(3)m&a&r&k&7&8&t&h&e&n&o&p - ejercicio 3
+D:mark 78 then open 90 mark 78 then open 90 mark 78 then open 90
+I:(4)t&h&e&b&a&c&o&n&p&s&l&v - ejercicio 4
+D:the beacon opens at level 28. the beacon opens at level 28.
+
+G:LANTERN_KEEP
+
+*:DAY_29
+B:KeyQuest - Dia 29 - Ashen Forge: Left Shift Spark
+T:Dia 29 guidance.
+ :Arco: Ashen Forge. teclas Shift y mayusculas.
+ :Enfoque: teclas Shift y mayusculas.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)A&S&D&F - ejercicio 1
+D:A S D F A S D F A S D F A S D F A S D F A S D F A S D F A S D F
+I:(2)A&a&S&s&D&d&F&f - ejercicio 2
+D:A a S s D d F f A a S s D d F f A a S s D d F f A a S s D d F f
+I:(3)A&s&k&D&a&d&F&l&S&f&e - ejercicio 3
+D:Ask Dad Fall Safe Ask Dad Fall Safe Ask Dad Fall Safe
+
+G:ASHEN_FORGE
+
+*:DAY_30
+B:KeyQuest - Dia 30 - Ashen Forge: Right Shift Spark
+T:Dia 30 guidance.
+ :Arco: Ashen Forge. teclas Shift y mayusculas.
+ :Enfoque: teclas Shift y mayusculas.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)J&K&L&H - ejercicio 1
+D:J K L H J K L H J K L H J K L H J K L H J K L H J K L H J K L H
+I:(2)J&j&K&k&L&l&H&h - ejercicio 2
+D:J j K k L l H h J j K k L l H h J j K k L l H h J j K k L l H h
+I:(3)J&o&y&K&e&L&a&k&H&i&l - ejercicio 3
+D:Joy Key Lake Hill Joy Key Lake Hill Joy Key Lake Hill
+
+G:ASHEN_FORGE
+
+*:DAY_31
+B:KeyQuest - Dia 31 - Ashen Forge: Capital Names
+T:Dia 31 guidance.
+ :Arco: Ashen Forge. teclas Shift y mayusculas.
+ :Enfoque: teclas Shift y mayusculas.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)A&d&a&K&e&n&L&i&J&o - ejercicio 1
+D:Ada Ken Lia Jo Ada Ken Lia Jo Ada Ken Lia Jo Ada Ken Lia Jo
+I:(2)M&i&r&a&N&o&V&l&e&O&w&n - ejercicio 2
+D:Mira Nora Vale Owen Mira Nora Vale Owen Mira Nora Vale Owen
+I:(3)A&d&a&n&K&e&r - ejercicio 3
+D:Ada and Ken read Ada and Ken read Ada and Ken read Ada and Ken read
+
+G:ASHEN_FORGE
+
+*:DAY_32
+B:KeyQuest - Dia 32 - Ashen Forge: Sentence Starts
+T:Dia 32 guidance.
+ :Arco: Ashen Forge. teclas Shift y mayusculas.
+ :Enfoque: teclas Shift y mayusculas.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)K&e&p&c&a&l&m&.&H&o&d&h - ejercicio 1
+D:Keep calm. Hold home. Type true.
+I:(2)T&h&e&f&o&r&g&l&w&s&.&k - ejercicio 2
+D:The forge glows. The key cools.
+I:(3)S&t&a&r&e&c&h&l&i&n&w&. - ejercicio 3
+D:Start each line with care.
+
+G:ASHEN_FORGE
+
+*:DAY_33
+B:KeyQuest - Dia 33 - Ashen Forge: Title Case
+T:Dia 33 guidance.
+ :Arco: Ashen Forge. teclas Shift y mayusculas.
+ :Enfoque: teclas Shift y mayusculas.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)A&s&h&e&n&F&o&r&g - ejercicio 1
+D:Ashen Forge Ashen Forge Ashen Forge Ashen Forge Ashen Forge
+I:(2)S&i&l&v&e&r&K&y&Q&u&t&G - ejercicio 2
+D:Silver Key Quiet Gate Silver Key Quiet Gate Silver Key Quiet Gate
+I:(3)T&h&e&B&r&i&g&t&A&n&v&l - ejercicio 3
+D:The Bright Anvil Shapes The Silent Key
+
+G:ASHEN_FORGE
+
+*:DAY_34
+B:KeyQuest - Dia 34 - Ashen Forge: Shift Review
+T:Dia 34 guidance.
+ :Arco: Ashen Forge. teclas Shift y mayusculas.
+ :Enfoque: teclas Shift y mayusculas.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)A&j&S&k&D&l&F&h - ejercicio 1
+D:A j S k D l F h A j S k D l F h A j S k D l F h A j S k D l F h
+I:(2)C&a&l&m&H&n&d&s&S&h&p&e - ejercicio 2
+D:Calm Hands Shape Bright Keys
+I:(3)A&s&t&e&a&d&y&h&n&c&l&i - ejercicio 3
+D:A steady hand can lift every letter.
+
+G:ASHEN_FORGE
+
+*:DAY_35
+B:KeyQuest - Dia 35 - Ashen Forge: Anvil Trial
+T:Dia 35 guidance.
+ :Arco: Ashen Forge. teclas Shift y mayusculas.
+ :Enfoque: teclas Shift y mayusculas.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)A&S&D&F&J&K&L&H - ejercicio 1
+D:A S D F J K L H A S D F J K L H A S D F J K L H A S D F J K L H
+I:(2)A&d&a&K&e&n&M&i&r&O&w - ejercicio 2
+D:Ada Ken Mira Owen Ada Ken Mira Owen Ada Ken Mira Owen
+I:(3)T&h&e&A&s&n&F&o&r&g&a&p - ejercicio 3
+D:The Ashen Forge shapes a calm bright key.
+I:(4)H&o&l&d&h&m&e&,&t&a&p&S - ejercicio 4
+D:Hold home, tap Shift, and let the anvil ring.
+
+G:ASHEN_FORGE
+
+*:DAY_36
+B:KeyQuest - Dia 36 - Windspire: Even Steps
+T:Dia 36 guidance.
+ :Arco: Windspire. control de velocidad y ritmo.
+ :Enfoque: control de velocidad y ritmo.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)t&a&p&r&e&s - ejercicio 1
+D:tap rest tap rest tap rest tap rest tap rest tap rest
+I:(2)c&a&l&m&p&e&s&t&d&y - ejercicio 2
+D:calm pace steady pace calm pace steady pace calm pace steady pace
+I:(3)E&v&e&r&y&s&m&a&l&t&p&k - ejercicio 3
+D:Every small step keeps the wind in time.
+
+G:WINDSPIRE
+
+*:DAY_37
+B:KeyQuest - Dia 37 - Windspire: Short Bursts
+T:Dia 37 guidance.
+ :Arco: Windspire. control de velocidad y ritmo.
+ :Enfoque: control de velocidad y ritmo.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)f&a&s&t&o&p&c&l&m&g - ejercicio 1
+D:fast stop calm go fast stop calm go fast stop calm go
+I:(2)w&i&n&d&r&u&s&t&h&e - ejercicio 2
+D:wind runs then rests wind runs then rests wind runs then rests
+I:(3)B&u&r&s&t&f&o&a&m&e&n&, - ejercicio 3
+D:Burst for a moment, then return to calm hands.
+
+G:WINDSPIRE
+
+*:DAY_38
+B:KeyQuest - Dia 38 - Windspire: Long Cadence
+T:Dia 38 guidance.
+ :Arco: Windspire. control de velocidad y ritmo.
+ :Enfoque: control de velocidad y ritmo.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)t&h&e&w&i&n&d&c&a&r&s&q - ejercicio 1
+D:the wind carries a quiet rhythm over the road
+I:(2)s&t&e&a&d&y&f&i&n&g&r&c - ejercicio 2
+D:steady fingers cross the high bridge with care
+I:(3)p&a&c&e&t&h&l&i&n&s&o&v - ejercicio 3
+D:pace the line so every word lands cleanly
+
+G:WINDSPIRE
+
+*:DAY_39
+B:KeyQuest - Dia 39 - Windspire: Alternate Pace
+T:Dia 39 guidance.
+ :Arco: Windspire. control de velocidad y ritmo.
+ :Enfoque: control de velocidad y ritmo.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)s&l&o&w&q&u&i&c&k - ejercicio 1
+D:slow slow quick quick slow slow quick quick slow slow quick quick
+I:(2)c&a&l&m&b&r&i&g&h&t - ejercicio 2
+D:calm calm bright bright calm calm bright bright
+I:(3)C&h&a&n&g&e&p&c&o&l&y&w - ejercicio 3
+D:Change pace only when the hands stay quiet.
+
+G:WINDSPIRE
+
+*:DAY_40
+B:KeyQuest - Dia 40 - Windspire: Breath Marks
+T:Dia 40 guidance.
+ :Arco: Windspire. control de velocidad y ritmo.
+ :Enfoque: control de velocidad y ritmo.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)b&r&e&a&t&h&,&y&p&u&s&. - ejercicio 1
+D:breathe, type, pause. breathe, type, pause.
+I:(2)s&h&o&r&t&w&i&n&d&,&l&g - ejercicio 2
+D:short wind, long road. calm hands, clean words.
+I:(3)L&e&t&a&c&h&o&m&s&l&w&r - ejercicio 3
+D:Let each comma slow the run.
+
+G:WINDSPIRE
+
+*:DAY_41
+B:KeyQuest - Dia 41 - Windspire: Gale Review
+T:Dia 41 guidance.
+ :Arco: Windspire. control de velocidad y ritmo.
+ :Enfoque: control de velocidad y ritmo.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)q&w&e&r&a&s&d&f&z&x&c&v - ejercicio 1
+D:qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv
+I:(2)u&i&o&p&j&k&l&;&n&m&,&. - ejercicio 2
+D:uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,.
+I:(3)s&t&e&a&d&y&p&c&o&v&r&1 - ejercicio 3
+D:steady pace over 12 stones and 34 rails
+
+G:WINDSPIRE
+
+*:DAY_42
+B:KeyQuest - Dia 42 - Windspire: Gale Trial
+T:Dia 42 guidance.
+ :Arco: Windspire. control de velocidad y ritmo.
+ :Enfoque: control de velocidad y ritmo.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)t&a&p&r&e&s&q&u&i&c&k&l - ejercicio 1
+D:tap rest quick calm tap rest quick calm tap rest quick calm
+I:(2)t&h&e&w&i&n&d&r&s&b&u&a - ejercicio 2
+D:the wind rises but the hands stay steady
+I:(3)q&u&i&c&k&s&t&e&p&a&r&f - ejercicio 3
+D:quick steps are useful only when accuracy holds
+I:(4)r&i&d&e&t&h&g&a&l&w&y&m - ejercicio 4
+D:ride the gale with rhythm, not panic.
+
+G:WINDSPIRE
+
+*:DAY_43
+B:KeyQuest - Dia 43 - Clockwork Citadel: Parentheses
+T:Dia 43 guidance.
+ :Arco: Clockwork Citadel. pares de programacion y corchetes.
+ :Enfoque: pares de programacion y corchetes.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)(&) - ejercicio 1
+D:( ) () ( ) () ( ) () ( ) () ( ) () ( ) () ( ) () ( ) () ( ) ()
+I:(2)(&a&)&k&e&y&m&p - ejercicio 2
+D:(a) (key) (map) (a) (key) (map) (a) (key) (map) (a) (key) (map)
+I:(3)o&p&e&n&(&t&h&g&a&)&d&c - ejercicio 3
+D:open (the gate) and close (the lock)
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_44
+B:KeyQuest - Dia 44 - Clockwork Citadel: Brackets
+T:Dia 44 guidance.
+ :Arco: Clockwork Citadel. pares de programacion y corchetes.
+ :Enfoque: pares de programacion y corchetes.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)[&] - ejercicio 1
+D:[ ] [] [ ] [] [ ] [] [ ] [] [ ] [] [ ] [] [ ] [] [ ] [] [ ] []
+I:(2)[&1&]&2&k&e&y - ejercicio 2
+D:[1] [2] [key] [1] [2] [key] [1] [2] [key] [1] [2] [key]
+I:(3)m&a&r&k&[&o&]&t&h&e&n&d - ejercicio 3
+D:mark [room] then read [signal]
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_45
+B:KeyQuest - Dia 45 - Clockwork Citadel: Braces
+T:Dia 45 guidance.
+ :Arco: Clockwork Citadel. pares de programacion y corchetes.
+ :Enfoque: pares de programacion y corchetes.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1){&} - ejercicio 1
+D:{ } {} { } {} { } {} { } {} { } {} { } {} { } {} { } {} { } {}
+I:(2){&k&e&y&}&g&a&t&m&p - ejercicio 2
+D:{key} {gate} {map} {key} {gate} {map} {key} {gate} {map}
+I:(3)s&t&o&r&e&{&l&i&g&h&}&b - ejercicio 3
+D:store {light} before {shadow}
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_46
+B:KeyQuest - Dia 46 - Clockwork Citadel: Angle Gates
+T:Dia 46 guidance.
+ :Arco: Clockwork Citadel. pares de programacion y corchetes.
+ :Enfoque: pares de programacion y corchetes.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)<&> - ejercicio 1
+D:< > <> < > <> < > <> < > <> < > <> < > <> < > <> < > <> < > <>
+I:(2)<&k&e&y&>&g&a&t&p&h - ejercicio 2
+D:<key> <gate> <path> <key> <gate> <path> <key> <gate> <path>
+I:(3)r&e&a&d&<&s&i&g&n&l&>&b - ejercicio 3
+D:read <signal> before <system> moves
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_47
+B:KeyQuest - Dia 47 - Clockwork Citadel: Nested Pairs
+T:Dia 47 guidance.
+ :Arco: Clockwork Citadel. pares de programacion y corchetes.
+ :Enfoque: pares de programacion y corchetes.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)(&[&]&)&{&} - ejercicio 1
+D:([]) ({}) ([]) ({}) ([]) ({}) ([]) ({}) ([]) ({}) ([]) ({})
+I:(2)[&m&a&p&]&(&r&o&)&{&k&e - ejercicio 2
+D:[map](room) {key} [map](room) {key} [map](room) {key}
+I:(3)o&p&e&n&(&[&q&u&i&t&]&) - ejercicio 3
+D:open ([quiet]) gears with {steady} hands
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_48
+B:KeyQuest - Dia 48 - Clockwork Citadel: Gear Review
+T:Dia 48 guidance.
+ :Arco: Clockwork Citadel. pares de programacion y corchetes.
+ :Enfoque: pares de programacion y corchetes.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)(&)&[&]&{&}&<&> - ejercicio 1
+D:() [] {} <> () [] {} <> () [] {} <> () [] {} <> () [] {} <>
+I:(2)g&e&a&r&[&1&]&t&u&n&s&( - ejercicio 2
+D:gear[1] turns (slow) while {hands} return
+I:(3)c&l&o&k&w&r&e&y&s&n&d&p - ejercicio 3
+D:clockwork keys need paired symbols in order
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_49
+B:KeyQuest - Dia 49 - Clockwork Citadel: Gearheart Trial
+T:Dia 49 guidance.
+ :Arco: Clockwork Citadel. pares de programacion y corchetes.
+ :Enfoque: pares de programacion y corchetes.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)(&)&[&]&{&}&<&> - ejercicio 1
+D:() [] {} <> () [] {} <> () [] {} <> () [] {} <> () [] {} <>
+I:(2)o&p&e&n&(&g&a&r&)&t&h&c - ejercicio 2
+D:open (gear) then close [vault] with {care}
+I:(3)t&h&e&<&g&a&r&>&c&p&s&l - ejercicio 3
+D:the <gearheart> accepts clean paired keys
+I:(4)m&a&t&c&h&e&v&r&y&b&k&f - ejercicio 4
+D:match every bracket before the engine wakes.
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_50
+B:KeyQuest - Dia 50 - Starfall Library: Math Signs
+T:Dia 50 guidance.
+ :Arco: Starfall Library. simbolos, operadores y flujo parecido a codigo.
+ :Enfoque: simbolos, operadores y flujo parecido a codigo.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)1&+&2&=&3 - ejercicio 1
+D:1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3
+I:(2)4&-&1&=&3 - ejercicio 2
+D:4 - 1 = 3 4 - 1 = 3 4 - 1 = 3 4 - 1 = 3 4 - 1 = 3 4 - 1 = 3
+I:(3)l&i&g&h&t&+&f&o&c&u&s&= - ejercicio 3
+D:light + focus = clear typing
+
+G:STARFALL_LIBRARY
+
+*:DAY_51
+B:KeyQuest - Dia 51 - Starfall Library: Slash And Star
+T:Dia 51 guidance.
+ :Arco: Starfall Library. simbolos, operadores y flujo parecido a codigo.
+ :Enfoque: simbolos, operadores y flujo parecido a codigo.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)/&* - ejercicio 1
+D:/ * / * / * / * / * / * / * / * / * / * / * / * / * / * / * / *
+I:(2)p&a&t&h&/&m&s&r&*&k&e&y - ejercicio 2
+D:path / map star * key path / map star * key path / map star * key
+I:(3)r&e&a&d&/&s&l&o&w&y&n&m - ejercicio 3
+D:read / slowly and mark * carefully
+
+G:STARFALL_LIBRARY
+
+*:DAY_52
+B:KeyQuest - Dia 52 - Starfall Library: Quotes
+T:Dia 52 guidance.
+ :Arco: Starfall Library. simbolos, operadores y flujo parecido a codigo.
+ :Enfoque: simbolos, operadores y flujo parecido a codigo.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)"&k&e&y&m&a&p - ejercicio 1
+D:"key" "map" "key" "map" "key" "map" "key" "map" "key" "map"
+I:(2)'&g&o&r&e&s&t - ejercicio 2
+D:'go' 'rest' 'go' 'rest' 'go' 'rest' 'go' 'rest' 'go' 'rest'
+I:(3)t&h&e&s&i&g&n&a&y&"&o&l - ejercicio 3
+D:the sign says "hold steady" before moving
+
+G:STARFALL_LIBRARY
+
+*:DAY_53
+B:KeyQuest - Dia 53 - Starfall Library: Colon Signals
+T:Dia 53 guidance.
+ :Arco: Starfall Library. simbolos, operadores y flujo parecido a codigo.
+ :Enfoque: simbolos, operadores y flujo parecido a codigo.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)k&e&y&:&g&a&t&;&m&p&h - ejercicio 1
+D:key: gate; map: path; key: gate; map: path; key: gate; map: path;
+I:(2)n&o&t&e&:&b&r&a&h&;&y&p - ejercicio 2
+D:note: breathe; type: slowly; check: accuracy;
+I:(3)s&i&g&n&a&l&:&c&e&r&;&h - ejercicio 3
+D:signal: clear; hands: calm; route: open;
+
+G:STARFALL_LIBRARY
+
+*:DAY_54
+B:KeyQuest - Dia 54 - Starfall Library: Code Words
+T:Dia 54 guidance.
+ :Arco: Starfall Library. simbolos, operadores y flujo parecido a codigo.
+ :Enfoque: simbolos, operadores y flujo parecido a codigo.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)i&f&g&a&t&e&=&o&p&n&h&y - ejercicio 1
+D:if gate = open then type calm words
+I:(2)c&o&u&n&t&+&f&s&-&p&a&i - ejercicio 2
+D:count + focus - panic = steady hands
+I:(3)p&a&t&h&/&r&o&m&k&e&y&s - ejercicio 3
+D:path / room / key keeps the record clear
+
+G:STARFALL_LIBRARY
+
+*:DAY_55
+B:KeyQuest - Dia 55 - Starfall Library: Archive Review
+T:Dia 55 guidance.
+ :Arco: Starfall Library. simbolos, operadores y flujo parecido a codigo.
+ :Enfoque: simbolos, operadores y flujo parecido a codigo.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)1&+&2&=&3&;&4&- - ejercicio 1
+D:1 + 2 = 3; 4 - 1 = 3; 1 + 2 = 3; 4 - 1 = 3; 1 + 2 = 3; 4 - 1 = 3;
+I:(2)r&e&c&o&d&:&"&s&t&a&y&; - ejercicio 2
+D:record: "steady"; status: "clear";
+I:(3)t&h&e&a&r&c&i&v&o&p&n&s - ejercicio 3
+D:the archive opens when symbols stay in order
+
+G:STARFALL_LIBRARY
+
+*:DAY_56
+B:KeyQuest - Dia 56 - Starfall Library: Archivist Trial
+T:Dia 56 guidance.
+ :Arco: Starfall Library. simbolos, operadores y flujo parecido a codigo.
+ :Enfoque: simbolos, operadores y flujo parecido a codigo.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)k&e&y&+&m&a&p&=&t&h&;&c - ejercicio 1
+D:key + map = path; path + calm = progress;
+I:(2)r&e&a&d&"&s&i&g&n&l&/&m - ejercicio 2
+D:read "signal" / mark "gate" / hold focus
+I:(3)i&f&r&o&m&=&c&l&e&a&t&h - ejercicio 3
+D:if room = clear then move slowly.
+I:(4)t&h&e&a&r&c&i&v&s&u&y&m - ejercicio 4
+D:the archivist trusts accurate symbols.
+
+G:STARFALL_LIBRARY
+
+*:DAY_57
+B:KeyQuest - Dia 57 - Dragon Spine: Pressure Warmup
+T:Dia 57 guidance.
+ :Arco: Dragon Spine. precision bajo presion.
+ :Enfoque: precision bajo presion.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)h&o&l&d&c&a&m&t&y&p&e&r - ejercicio 1
+D:hold calm type true hold calm type true hold calm type true
+I:(2)t&h&e&r&i&d&g&s&b&u&a&n - ejercicio 2
+D:the ridge is high but the hands stay low
+I:(3)a&c&u&r&y&i&s&t&h&e&l&d - ejercicio 3
+D:accuracy is the shield before speed.
+
+G:DRAGON_SPINE
+
+*:DAY_58
+B:KeyQuest - Dia 58 - Dragon Spine: Longer Climb
+T:Dia 58 guidance.
+ :Arco: Dragon Spine. precision bajo presion.
+ :Enfoque: precision bajo presion.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)t&h&e&d&r&a&g&o&n&i&s&b - ejercicio 1
+D:the dragon road rises beyond the quiet stone gate
+I:(2)e&a&c&h&r&f&u&l&w&o&d&k - ejercicio 2
+D:each careful word keeps the traveler on the ridge
+I:(3)f&i&n&s&h&t&e&l&a&c&y&b - ejercicio 3
+D:finish the line as cleanly as it began
+
+G:DRAGON_SPINE
+
+*:DAY_59
+B:KeyQuest - Dia 59 - Dragon Spine: Heat Control
+T:Dia 59 guidance.
+ :Arco: Dragon Spine. precision bajo presion.
+ :Enfoque: precision bajo presion.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)G&a&t&e&1&2&o&p&n&s&f&r - ejercicio 1
+D:Gate 12 opens after Signal 34.
+I:(2)D&r&a&g&o&n&7&c&i&l&e&s - ejercicio 2
+D:Dragon 7 circles Tower 9 before dawn.
+I:(3)K&e&p&3&c&a&l&m&b&r&t&h - ejercicio 3
+D:Keep 3 calm breaths before Route 5.
+
+G:DRAGON_SPINE
+
+*:DAY_60
+B:KeyQuest - Dia 60 - Dragon Spine: No Panic
+T:Dia 60 guidance.
+ :Arco: Dragon Spine. precision bajo presion.
+ :Enfoque: precision bajo presion.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)b&r&e&a&t&h&,&c&o&n&i&u - ejercicio 1
+D:breathe, correct, continue; do not chase the error.
+I:(2)t&h&e&o&p&a&b&n&d&s&,&u - ejercicio 2
+D:the hot path bends, but steady fingers recover.
+I:(3)s&l&o&w&c&r&e&t&i&n&b&a - ejercicio 3
+D:slow correction beats fast panic every time.
+
+G:DRAGON_SPINE
+
+*:DAY_61
+B:KeyQuest - Dia 61 - Dragon Spine: Focus Run
+T:Dia 61 guidance.
+ :Arco: Dragon Spine. precision bajo presion.
+ :Enfoque: precision bajo presion.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)T&h&e&b&r&i&g&t&d&n&a&o - ejercicio 1
+D:The bright ridge narrows as the old dragon wakes.
+I:(2)A&c&a&l&m&t&r&v&e&d&s&h - ejercicio 2
+D:A calm traveler reads the wind and keeps moving.
+I:(3)E&v&e&r&y&c&l&a&n&w&o&d - ejercicio 3
+D:Every clean word becomes another safe step.
+
+G:DRAGON_SPINE
+
+*:DAY_62
+B:KeyQuest - Dia 62 - Dragon Spine: Wyrm Review
+T:Dia 62 guidance.
+ :Arco: Dragon Spine. precision bajo presion.
+ :Enfoque: precision bajo presion.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)R&o&u&t&e&4&2&:&c&l&i&m - ejercicio 1
+D:Route 42: climb, pause, breathe, continue.
+I:(2)T&h&e&r&i&d&g&m&a&k&s&y - ejercicio 2
+D:The ridge marker says "steady hands survive."
+I:(3)f&o&c&u&s&+&p&a&t&i&e&n - ejercicio 3
+D:focus + patience = safe travel under pressure
+
+G:DRAGON_SPINE
+
+*:DAY_63
+B:KeyQuest - Dia 63 - Dragon Spine: Wyrm Trial
+T:Dia 63 guidance.
+ :Arco: Dragon Spine. precision bajo presion.
+ :Enfoque: precision bajo presion.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)T&h&e&d&r&a&g&o&n&w&t&c - ejercicio 1
+D:The dragon watches each key and every pause.
+I:(2)R&o&u&t&e&6&3&i&s&n&a&r - ejercicio 2
+D:Route 63 is narrow, bright, and unforgiving.
+I:(3)B&r&e&a&t&h&,&y&p&c&o&v - ejercicio 3
+D:Breathe, type, recover; the ridge will not hurry.
+I:(4)T&h&e&w&y&r&m&i&l&d&s&t - ejercicio 4
+D:The wyrm yields to calm accurate hands.
+
+G:DRAGON_SPINE
+
+*:DAY_64
+B:KeyQuest - Dia 64 - Moonlit Labyrinth: Slow Repair
+T:Dia 64 guidance.
+ :Arco: Moonlit Labyrinth. recuperacion de teclas debiles y correccion
+ :calmada.
+ :Enfoque: recuperacion de teclas debiles y correccion calmada.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)q&z&p&; - ejercicio 1
+D:q z p ; q z p ; q z p ; q z p ; q z p ; q z p ; q z p ; q z p ;
+I:(2)v&b&n&m - ejercicio 2
+D:v b n m v b n m v b n m v b n m v b n m v b n m v b n m v b n m
+I:(3)s&l&o&w&r&e&p&a&i&m&k&t - ejercicio 3
+D:slow repair makes the lost path visible
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_65
+B:KeyQuest - Dia 65 - Moonlit Labyrinth: Outer Keys
+T:Dia 65 guidance.
+ :Arco: Moonlit Labyrinth. recuperacion de teclas debiles y correccion
+ :calmada.
+ :Enfoque: recuperacion de teclas debiles y correccion calmada.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)q&a&;&p - ejercicio 1
+D:qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p
+I:(2)z&q&p&; - ejercicio 2
+D:zq p; zq p; zq p; zq p; zq p; zq p; zq p; zq p; zq p; zq p;
+I:(3)q&u&i&e&t&p&a&h&s&b&y&o - ejercicio 3
+D:quiet paths pass beyond pale pillars
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_66
+B:KeyQuest - Dia 66 - Moonlit Labyrinth: Bottom Repair
+T:Dia 66 guidance.
+ :Arco: Moonlit Labyrinth. recuperacion de teclas debiles y correccion
+ :calmada.
+ :Enfoque: recuperacion de teclas debiles y correccion calmada.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)c&v&n&m&b - ejercicio 1
+D:cv nm vb cv nm vb cv nm vb cv nm vb cv nm vb cv nm vb cv nm vb
+I:(2)m&o&v&e&b&r&a&n&c&l - ejercicio 2
+D:move brave never calm move brave never calm move brave never calm
+I:(3)t&h&e&m&a&z&b&n&d&s&l&o - ejercicio 3
+D:the maze bends below the home row
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_67
+B:KeyQuest - Dia 67 - Moonlit Labyrinth: Symbol Repair
+T:Dia 67 guidance.
+ :Arco: Moonlit Labyrinth. recuperacion de teclas debiles y correccion
+ :calmada.
+ :Enfoque: recuperacion de teclas debiles y correccion calmada.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)(&)&[&]&{&} - ejercicio 1
+D:() [] {} () [] {} () [] {} () [] {} () [] {} () [] {} () [] {}
+I:(2)1&+&2&=&3 - ejercicio 2
+D:1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3
+I:(3)r&e&p&a&i&[&s&m&l&]&o&b - ejercicio 3
+D:repair [small] errors before {large} ones
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_68
+B:KeyQuest - Dia 68 - Moonlit Labyrinth: Mirror Paths
+T:Dia 68 guidance.
+ :Arco: Moonlit Labyrinth. recuperacion de teclas debiles y correccion
+ :calmada.
+ :Enfoque: recuperacion de teclas debiles y correccion calmada.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)a&s&d&f&j&k&l&; - ejercicio 1
+D:asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj
+I:(2)q&w&e&r&u&i&o&p - ejercicio 2
+D:qwer rewq uiop poiu qwer rewq uiop poiu qwer rewq uiop poiu
+I:(3)l&e&f&t&p&a&h&r&i&g&b&o - ejercicio 3
+D:left path right path both return home
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_69
+B:KeyQuest - Dia 69 - Moonlit Labyrinth: Labyrinth Review
+T:Dia 69 guidance.
+ :Arco: Moonlit Labyrinth. recuperacion de teclas debiles y correccion
+ :calmada.
+ :Enfoque: recuperacion de teclas debiles y correccion calmada.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)q&u&i&e&t&z&b&r&a&p&h&s - ejercicio 1
+D:quiet zebra paths puzzle every brave novice
+I:(2)s&y&m&b&o&l&,&n&u&e&r&a - ejercicio 2
+D:symbols, numbers, and outer keys need patience.
+I:(3)c&o&r&e&t&h&s&m&a&l&i&b - ejercicio 3
+D:correct the small miss before moving onward
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_70
+B:KeyQuest - Dia 70 - Moonlit Labyrinth: Minotaur Trial
+T:Dia 70 guidance.
+ :Arco: Moonlit Labyrinth. recuperacion de teclas debiles y correccion
+ :calmada.
+ :Enfoque: recuperacion de teclas debiles y correccion calmada.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)q&z&p&;&v&b&n&m - ejercicio 1
+D:q z p ; v b n m q z p ; v b n m q z p ; v b n m q z p ; v b n m
+I:(2)q&u&i&e&t&s&y&m&b&o&l&[ - ejercicio 2
+D:quiet symbols [return] after {careful} repair
+I:(3)t&h&e&m&a&z&r&w&d&s&p&i - ejercicio 3
+D:the maze rewards patience, not panic.
+I:(4)r&e&c&o&v&a&h&k&y&n&d&l - ejercicio 4
+D:recover each key and leave the labyrinth.
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_71
+B:KeyQuest - Dia 71 - Obsidian Throne: Mixed Marks
+T:Dia 71 guidance.
+ :Arco: Obsidian Throne. puntuacion mixta y foco en textos largos.
+ :Enfoque: puntuacion mixta y foco en textos largos.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)w&a&i&t&,&l&o&k&;&y&p&e - ejercicio 1
+D:wait, look; type: slowly.
+I:(2)k&e&y&:&f&o&u&n&d&,&g&a - ejercicio 2
+D:key: found, gate: open, path: clear.
+I:(3)t&h&e&r&o&n&i&s&d&a&k&; - ejercicio 3
+D:the throne is dark; the signal is bright.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_72
+B:KeyQuest - Dia 72 - Obsidian Throne: Quote Orders
+T:Dia 72 guidance.
+ :Arco: Obsidian Throne. puntuacion mixta y foco en textos largos.
+ :Enfoque: puntuacion mixta y foco en textos largos.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)T&h&e&g&u&a&r&d&s&y&,&" - ejercicio 1
+D:The guard says, "hold the line."
+I:(2)T&h&e&m&a&p&r&d&s&,&"&t - ejercicio 2
+D:The map reads, "turn left, then pause."
+I:(3)S&h&e&w&i&s&p&r&,&"&a&c - ejercicio 3
+D:She whispers, "accuracy breaks the seal."
+
+G:OBSIDIAN_THRONE
+
+*:DAY_73
+B:KeyQuest - Dia 73 - Obsidian Throne: Long Focus
+T:Dia 73 guidance.
+ :Arco: Obsidian Throne. puntuacion mixta y foco en textos largos.
+ :Enfoque: puntuacion mixta y foco en textos largos.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)B&e&y&o&n&d&t&h&b&l&a&c - ejercicio 1
+D:Beyond the black hall, every comma becomes a breath.
+I:(2)T&h&e&o&l&d&c&r&w&n&a&i - ejercicio 2
+D:The old crown waits; calm hands answer without fear.
+I:(3)A&l&o&n&g&i&e&s&y&v&r&a - ejercicio 3
+D:A long line is only several small clean choices.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_74
+B:KeyQuest - Dia 74 - Obsidian Throne: Clause Chains
+T:Dia 74 guidance.
+ :Arco: Obsidian Throne. puntuacion mixta y foco en textos largos.
+ :Enfoque: puntuacion mixta y foco en textos largos.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)l&o&k&a&h&e&d&;&b&r&t&n - ejercicio 1
+D:look ahead; breathe once; type the next word.
+I:(2)t&h&e&a&l&n&r&o&w&s&;&c - ejercicio 2
+D:the hall narrows; the torch dims; focus remains.
+I:(3)s&l&o&w&h&a&n&d&i&;&r&u - ejercicio 3
+D:slow hands win; rushed hands repeat the lesson.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_75
+B:KeyQuest - Dia 75 - Obsidian Throne: Dense Review
+T:Dia 75 guidance.
+ :Arco: Obsidian Throne. puntuacion mixta y foco en textos largos.
+ :Enfoque: puntuacion mixta y foco en textos largos.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)R&o&m&7&5&:&"&s&t&e&a&d - ejercicio 1
+D:Room 75: "steady," says the silent crown.
+I:(2)G&a&t&e&3&o&p&n&s&;&4&w - ejercicio 2
+D:Gate 3 opens; Gate 4 waits; Gate 5 listens.
+I:(3)c&l&e&a&r&m&k&s&,&n&w&o - ejercicio 3
+D:clear marks, clean words, and calm recovery.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_76
+B:KeyQuest - Dia 76 - Obsidian Throne: Crown Approach
+T:Dia 76 guidance.
+ :Arco: Obsidian Throne. puntuacion mixta y foco en textos largos.
+ :Enfoque: puntuacion mixta y foco en textos largos.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)T&h&e&o&b&s&i&d&a&n&t&p - ejercicio 1
+D:The obsidian steps rise slowly toward the throne.
+I:(2)E&a&c&h&m&r&k&t&e&s&:&o - ejercicio 2
+D:Each mark matters: comma, period, colon, quote.
+I:(3)D&o&n&t&r&u&s&h&e&f&i&a - ejercicio 3
+D:Do not rush the final line before the crown.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_77
+B:KeyQuest - Dia 77 - Obsidian Throne: Crown Trial
+T:Dia 77 guidance.
+ :Arco: Obsidian Throne. puntuacion mixta y foco en textos largos.
+ :Enfoque: puntuacion mixta y foco en textos largos.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)T&h&e&c&r&o&w&n&s&a&y&, - ejercicio 1
+D:The crown says, "type clearly, then continue."
+I:(2)R&o&m&7&:&p&a&u&s&e&,&b - ejercicio 2
+D:Room 77: pause, breathe, correct, proceed.
+I:(3)L&o&n&g&f&c&u&s&t&r&d&a - ejercicio 3
+D:Long focus turns dark punctuation into light.
+I:(4)T&h&e&t&r&o&n&p&s&f&a&d - ejercicio 4
+D:The throne opens for steady accurate hands.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_78
+B:KeyQuest - Dia 78 - Dawn Citadel: Full Keyboard Scan
+T:Dia 78 guidance.
+ :Arco: Dawn Citadel. repaso de dominio de todo el teclado.
+ :Enfoque: repaso de dominio de todo el teclado.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)q&w&e&r&a&s&d&f&z&x&c&v - ejercicio 1
+D:qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv
+I:(2)u&i&o&p&j&k&l&;&n&m&,&. - ejercicio 2
+D:uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,.
+I:(3)1&2&3&4&5&6&7&8&9&0 - ejercicio 3
+D:1234 567 890 1234 567 890 1234 567 890 1234 567 890 1234 567 890
+
+G:DAWN_CITADEL
+
+*:DAY_79
+B:KeyQuest - Dia 79 - Dawn Citadel: Capital Review
+T:Dia 79 guidance.
+ :Arco: Dawn Citadel. repaso de dominio de todo el teclado.
+ :Enfoque: repaso de dominio de todo el teclado.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)D&a&w&n&C&i&t&d&e&l&o&p - ejercicio 1
+D:Dawn Citadel opens Gate 79 with calm hands.
+I:(2)M&i&r&a&n&d&O&w&e&c&y&K - ejercicio 2
+D:Mira and Owen carry Key 12 to Tower 34.
+I:(3)E&v&e&r&y&C&a&p&i&t&l&L - ejercicio 3
+D:Every Capital Letter returns to home.
+
+G:DAWN_CITADEL
+
+*:DAY_80
+B:KeyQuest - Dia 80 - Dawn Citadel: Symbol Review
+T:Dia 80 guidance.
+ :Arco: Dawn Citadel. repaso de dominio de todo el teclado.
+ :Enfoque: repaso de dominio de todo el teclado.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)(&)&[&]&{&}&<&> - ejercicio 1
+D:() [] {} <> () [] {} <> () [] {} <> () [] {} <> () [] {} <>
+I:(2)1&+&2&=&3&; - ejercicio 2
+D:1 + 2 = 3; 1 + 2 = 3; 1 + 2 = 3; 1 + 2 = 3; 1 + 2 = 3; 1 + 2 = 3;
+I:(3)r&e&c&o&d&[&a&w&n&]&=&{ - ejercicio 3
+D:record [dawn] = {clear} + "focus"
+
+G:DAWN_CITADEL
+
+*:DAY_81
+B:KeyQuest - Dia 81 - Dawn Citadel: Phrase Review
+T:Dia 81 guidance.
+ :Arco: Dawn Citadel. repaso de dominio de todo el teclado.
+ :Enfoque: repaso de dominio de todo el teclado.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)t&h&e&d&a&w&n&c&i&l&g&r - ejercicio 1
+D:the dawn citadel gathers every lesson into one path
+I:(2)s&t&e&a&d&y&r&h&m&c&i&l - ejercicio 2
+D:steady rhythm carries letters, numbers, and marks
+I:(3)f&u&l&m&a&s&t&e&r&y&b&g - ejercicio 3
+D:full mastery begins with one clean line at a time
+
+G:DAWN_CITADEL
+
+*:DAY_82
+B:KeyQuest - Dia 82 - Dawn Citadel: Recovery Review
+T:Dia 82 guidance.
+ :Arco: Dawn Citadel. repaso de dominio de todo el teclado.
+ :Enfoque: repaso de dominio de todo el teclado.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)q&z&p&;&v&b&n&m - ejercicio 1
+D:q z p ; v b n m q z p ; v b n m q z p ; v b n m q z p ; v b n m
+I:(2)r&e&c&o&v&[&q&u&i&t&l&y - ejercicio 2
+D:recover [quietly] after {difficult} symbols
+I:(3)t&h&e&c&i&a&d&l&r&w&s&m - ejercicio 3
+D:the citadel rewards calm correction
+
+G:DAWN_CITADEL
+
+*:DAY_83
+B:KeyQuest - Dia 83 - Dawn Citadel: Final Review
+T:Dia 83 guidance.
+ :Arco: Dawn Citadel. repaso de dominio de todo el teclado.
+ :Enfoque: repaso de dominio de todo el teclado.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)G&a&t&e&8&3&o&p&n&s&w&h - ejercicio 1
+D:Gate 83 opens when "focus" stays bright.
+I:(2)D&a&w&n&l&i&g&h&t&c&r&o - ejercicio 2
+D:Dawn light crosses room 12, hall 34, and tower 56.
+I:(3)t&y&p&e&s&l&o&w&n&u&g&h - ejercicio 3
+D:type slowly enough to finish cleanly
+
+G:DAWN_CITADEL
+
+*:DAY_84
+B:KeyQuest - Dia 84 - Dawn Citadel: Dawn Trial
+T:Dia 84 guidance.
+ :Arco: Dawn Citadel. repaso de dominio de todo el teclado.
+ :Enfoque: repaso de dominio de todo el teclado.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)q&w&e&r&a&s&d&f&z&x&c&v - ejercicio 1
+D:qwer asdf zxcv uiop qwer asdf zxcv uiop qwer asdf zxcv uiop
+I:(2)D&a&w&n&C&i&t&d&e&l&:&[ - ejercicio 2
+D:Dawn Citadel: [ready] = {calm} + "accuracy"
+I:(3)E&v&e&r&y&o&w&,&n&u&m&b - ejercicio 3
+D:Every row, number, and mark returns home.
+I:(4)T&h&e&f&i&n&a&l&g&t&p&r - ejercicio 4
+D:The final gate appears in the morning light.
+
+G:DAWN_CITADEL
+
+*:DAY_85
+B:KeyQuest - Dia 85 - Final Gate: First Seal
+T:Dia 85 guidance.
+ :Arco: Final Gate. mision final de tipeo integrado.
+ :Enfoque: mision final de tipeo integrado.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)a&s&d&f&q&w&e&r&z&x&c&v - ejercicio 1
+D:asdf qwer zxcv 1234 asdf qwer zxcv 1234 asdf qwer zxcv 1234
+I:(2)T&h&e&f&i&r&s&t&a&l&o&p - ejercicio 2
+D:The first seal opens for calm accurate hands.
+I:(3)R&e&v&i&w&r&y&o&b&f&t&h - ejercicio 3
+D:Review every row before the final spell begins.
+I:(4)s&t&e&a&d&y&f&o&c&u&r&i - ejercicio 4
+D:steady focus carries the key toward silence
+
+G:FINAL_GATE
+
+*:DAY_86
+B:KeyQuest - Dia 86 - Final Gate: Second Seal
+T:Dia 86 guidance.
+ :Arco: Final Gate. mision final de tipeo integrado.
+ :Enfoque: mision final de tipeo integrado.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)S&e&a&l&2&:&"&H&o&d&f&c - ejercicio 1
+D:Seal 2: "Hold focus," says the old gate.
+I:(2)K&e&y&8&6&t&u&r&n&s&l&o - ejercicio 2
+D:Key 86 turns slowly; the path remains clear.
+I:(3)A&B&r&i&g&h&t&H&a&n&d&y - ejercicio 3
+D:A Bright Hand types 3 clean lines before dawn.
+I:(4)n&u&m&b&e&r&s&a&d&k&o&y - ejercicio 4
+D:numbers and marks obey patient fingers
+
+G:FINAL_GATE
+
+*:DAY_87
+B:KeyQuest - Dia 87 - Final Gate: Third Seal
+T:Dia 87 guidance.
+ :Arco: Final Gate. mision final de tipeo integrado.
+ :Enfoque: mision final de tipeo integrado.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)i&f&g&a&t&e&=&o&p&n&h&l - ejercicio 1
+D:if gate = open then hold steady focus
+I:(2)f&i&n&a&l&[&s&e&]&=&{&c - ejercicio 2
+D:final[seal] = {calm} + "accuracy"
+I:(3)p&a&t&h&/&k&e&y&l&i&g&d - ejercicio 3
+D:path / key / light leads beyond silence
+I:(4)p&a&i&r&e&d&s&y&m&b&o&l - ejercicio 4
+D:paired symbols guard the third seal
+
+G:FINAL_GATE
+
+*:DAY_88
+B:KeyQuest - Dia 88 - Final Gate: Fourth Seal
+T:Dia 88 guidance.
+ :Arco: Final Gate. mision final de tipeo integrado.
+ :Enfoque: mision final de tipeo integrado.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)T&h&e&L&o&r&d&f&S&i&l&n - ejercicio 1
+D:The Lord of Silence waits beyond the final gate.
+I:(2)E&v&e&r&y&l&s&o&n&t&u&a - ejercicio 2
+D:Every lesson returns as one quiet line of light.
+I:(3)D&o&n&t&r&u&s&h&e&d&i&g - ejercicio 3
+D:Do not rush the ending; complete it cleanly.
+I:(4)a&c&u&r&y&t&n&s&h&e&l&d - ejercicio 4
+D:accuracy turns the last shadow into dawn
+
+G:FINAL_GATE
+
+*:DAY_89
+B:KeyQuest - Dia 89 - Final Gate: Last Camp
+T:Dia 89 guidance.
+ :Arco: Final Gate. mision final de tipeo integrado.
+ :Enfoque: mision final de tipeo integrado.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)N&o&v&i&c&e&h&a&n&d&s&b - ejercicio 1
+D:Novice hands became steady hands over many days.
+I:(2)R&o&w&s&,&n&u&m&b&e&r&y - ejercicio 2
+D:Rows, numbers, symbols, and stories gather here.
+I:(3)B&r&e&a&t&h&o&n&c&b&f&i - ejercicio 3
+D:Breathe once before the final spell is typed.
+I:(4)t&h&e&l&a&s&c&m&p&i&q&u - ejercicio 4
+D:the last camp is quiet, bright, and ready
+
+G:FINAL_GATE
+
+*:DAY_90
+B:KeyQuest - Dia 90 - Final Gate: Last Spell Trial
+T:Dia 90 guidance.
+ :Arco: Final Gate. mision final de tipeo integrado.
+ :Enfoque: mision final de tipeo integrado.
+ :Prioriza la precision; deja que la velocidad llegue tras una linea limpia.
+I:(1)T&h&e&f&i&n&a&l&g&t&o&p - ejercicio 1
+D:The final gate opens when every key returns home.
+I:(2)K&e&y&Q&u&s&t&D&a&9&0&: - ejercicio 2
+D:KeyQuest Day 90: "Accuracy breaks the silence."
+I:(3)i&f&o&c&u&s&=&t&e&a&d&y - ejercicio 3
+D:if focus = steady then the last spell shines
+I:(4)T&h&e&L&o&r&d&f&S&i&l&n - ejercicio 4
+D:The Lord of Silence falls to calm typing.
+
+G:FINAL_GATE
+
+*:ABOUT
+B:Acerca del viaje de mecanografia KeyQuest
+T:Este script de GNU Typist adapta KeyQuest a un viaje de mecanografia de 90
+ :dias.
+ :Las lineas D: que escribes permanecen en ingles y son identicas en todos
+ :los idiomas.
+ :Solo se localizan menus, titulos y explicaciones.
+ :Practica un dia por sesion y repite cuando baje la precision.
+G:MENU
+*:EXIT
+B:Gracias por entrenar con KeyQuest.
+T:Practica un poco cada dia. La precision abre la puerta final.
+X:

--- a/keyquest.fr.typ
+++ b/keyquest.fr.typ
@@ -1,0 +1,1588 @@
+*:MENU
+M: "Voyage de frappe KeyQuest"
+ :NOVICE_HALL  "Novice Hall"
+ :MEADOW_ROAD  "Meadow Road"
+ :RIVER_GATE  "River Gate"
+ :LANTERN_KEEP  "Lantern Keep"
+ :ASHEN_FORGE  "Ashen Forge"
+ :WINDSPIRE  "Windspire"
+ :CLOCKWORK_CITADEL  "Clockwork Citadel"
+ :STARFALL_LIBRARY  "Starfall Library"
+ :DRAGON_SPINE  "Dragon Spine"
+ :MOONLIT_LABYRINTH  "Moonlit Labyrinth"
+ :OBSIDIAN_THRONE  "Obsidian Throne"
+ :DAWN_CITADEL  "Dawn Citadel"
+ :FINAL_GATE  "Final Gate"
+ :ABOUT  "A propos de ce script"
+ :EXIT  "Quitter"
+
+*:NOVICE_HALL
+M: "Novice Hall"
+ :DAY_01  "Jour 01: Home Position"
+ :DAY_02  "Jour 02: Left And Right Balance"
+ :DAY_03  "Jour 03: Finger Responsibility"
+ :DAY_04  "Jour 04: Rhythm Hall"
+ :DAY_05  "Jour 05: First Words"
+ :DAY_06  "Jour 06: Repair The Stance"
+ :DAY_07  "Jour 07: Gatekeeper Trial"
+ :MENU  "Retour au menu de l arc"
+
+*:MEADOW_ROAD
+M: "Meadow Road"
+ :DAY_08  "Jour 08: First Steps Beyond Home"
+ :DAY_09  "Jour 09: Ring Finger Reach"
+ :DAY_10  "Jour 10: Index Reach"
+ :DAY_11  "Jour 11: Outer Watch"
+ :DAY_12  "Jour 12: Top Row Trail"
+ :DAY_13  "Jour 13: First Flow"
+ :DAY_14  "Jour 14: Waystone Trial"
+ :MENU  "Retour au menu de l arc"
+
+*:RIVER_GATE
+M: "River Gate"
+ :DAY_15  "Jour 15: Lower Step"
+ :DAY_16  "Jour 16: Valley Reach"
+ :DAY_17  "Jour 17: Bridge Keys"
+ :DAY_18  "Jour 18: Comma And Period"
+ :DAY_19  "Jour 19: Bottom Row Words"
+ :DAY_20  "Jour 20: Current Review"
+ :DAY_21  "Jour 21: Ferryman Trial"
+ :MENU  "Retour au menu de l arc"
+
+*:LANTERN_KEEP
+M: "Lantern Keep"
+ :DAY_22  "Jour 22: Left Number Row"
+ :DAY_23  "Jour 23: Right Number Row"
+ :DAY_24  "Jour 24: Center Span"
+ :DAY_25  "Jour 25: Counts And Codes"
+ :DAY_26  "Jour 26: Map Marks"
+ :DAY_27  "Jour 27: Mixed Signals"
+ :DAY_28  "Jour 28: Beacon Trial"
+ :MENU  "Retour au menu de l arc"
+
+*:ASHEN_FORGE
+M: "Ashen Forge"
+ :DAY_29  "Jour 29: Left Shift Spark"
+ :DAY_30  "Jour 30: Right Shift Spark"
+ :DAY_31  "Jour 31: Capital Names"
+ :DAY_32  "Jour 32: Sentence Starts"
+ :DAY_33  "Jour 33: Title Case"
+ :DAY_34  "Jour 34: Shift Review"
+ :DAY_35  "Jour 35: Anvil Trial"
+ :MENU  "Retour au menu de l arc"
+
+*:WINDSPIRE
+M: "Windspire"
+ :DAY_36  "Jour 36: Even Steps"
+ :DAY_37  "Jour 37: Short Bursts"
+ :DAY_38  "Jour 38: Long Cadence"
+ :DAY_39  "Jour 39: Alternate Pace"
+ :DAY_40  "Jour 40: Breath Marks"
+ :DAY_41  "Jour 41: Gale Review"
+ :DAY_42  "Jour 42: Gale Trial"
+ :MENU  "Retour au menu de l arc"
+
+*:CLOCKWORK_CITADEL
+M: "Clockwork Citadel"
+ :DAY_43  "Jour 43: Parentheses"
+ :DAY_44  "Jour 44: Brackets"
+ :DAY_45  "Jour 45: Braces"
+ :DAY_46  "Jour 46: Angle Gates"
+ :DAY_47  "Jour 47: Nested Pairs"
+ :DAY_48  "Jour 48: Gear Review"
+ :DAY_49  "Jour 49: Gearheart Trial"
+ :MENU  "Retour au menu de l arc"
+
+*:STARFALL_LIBRARY
+M: "Starfall Library"
+ :DAY_50  "Jour 50: Math Signs"
+ :DAY_51  "Jour 51: Slash And Star"
+ :DAY_52  "Jour 52: Quotes"
+ :DAY_53  "Jour 53: Colon Signals"
+ :DAY_54  "Jour 54: Code Words"
+ :DAY_55  "Jour 55: Archive Review"
+ :DAY_56  "Jour 56: Archivist Trial"
+ :MENU  "Retour au menu de l arc"
+
+*:DRAGON_SPINE
+M: "Dragon Spine"
+ :DAY_57  "Jour 57: Pressure Warmup"
+ :DAY_58  "Jour 58: Longer Climb"
+ :DAY_59  "Jour 59: Heat Control"
+ :DAY_60  "Jour 60: No Panic"
+ :DAY_61  "Jour 61: Focus Run"
+ :DAY_62  "Jour 62: Wyrm Review"
+ :DAY_63  "Jour 63: Wyrm Trial"
+ :MENU  "Retour au menu de l arc"
+
+*:MOONLIT_LABYRINTH
+M: "Moonlit Labyrinth"
+ :DAY_64  "Jour 64: Slow Repair"
+ :DAY_65  "Jour 65: Outer Keys"
+ :DAY_66  "Jour 66: Bottom Repair"
+ :DAY_67  "Jour 67: Symbol Repair"
+ :DAY_68  "Jour 68: Mirror Paths"
+ :DAY_69  "Jour 69: Labyrinth Review"
+ :DAY_70  "Jour 70: Minotaur Trial"
+ :MENU  "Retour au menu de l arc"
+
+*:OBSIDIAN_THRONE
+M: "Obsidian Throne"
+ :DAY_71  "Jour 71: Mixed Marks"
+ :DAY_72  "Jour 72: Quote Orders"
+ :DAY_73  "Jour 73: Long Focus"
+ :DAY_74  "Jour 74: Clause Chains"
+ :DAY_75  "Jour 75: Dense Review"
+ :DAY_76  "Jour 76: Crown Approach"
+ :DAY_77  "Jour 77: Crown Trial"
+ :MENU  "Retour au menu de l arc"
+
+*:DAWN_CITADEL
+M: "Dawn Citadel"
+ :DAY_78  "Jour 78: Full Keyboard Scan"
+ :DAY_79  "Jour 79: Capital Review"
+ :DAY_80  "Jour 80: Symbol Review"
+ :DAY_81  "Jour 81: Phrase Review"
+ :DAY_82  "Jour 82: Recovery Review"
+ :DAY_83  "Jour 83: Final Review"
+ :DAY_84  "Jour 84: Dawn Trial"
+ :MENU  "Retour au menu de l arc"
+
+*:FINAL_GATE
+M: "Final Gate"
+ :DAY_85  "Jour 85: First Seal"
+ :DAY_86  "Jour 86: Second Seal"
+ :DAY_87  "Jour 87: Third Seal"
+ :DAY_88  "Jour 88: Fourth Seal"
+ :DAY_89  "Jour 89: Last Camp"
+ :DAY_90  "Jour 90: Last Spell Trial"
+ :MENU  "Retour au menu de l arc"
+
+*:DAY_01
+B:KeyQuest - Jour 01 - Novice Hall: Home Position
+T:Jour 01 guidance.
+ :Arc: Novice Hall. position de base et role de chaque doigt.
+ :Objectif: position de base et role de chaque doigt.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)f&j - exercice 1
+D:f j f j f j f j f j f j f j f j
+I:(2)f&j - exercice 2
+D:ff jj ff jj ff jj ff jj ff jj ff jj ff jj ff jj
+I:(3)f&j - exercice 3
+D:fj jf fj jf fj jf fj jf fj jf fj jf fj jf fj jf
+I:(4)a&s&d&f&j&k&l&; - exercice 4
+D:asdf jkl; asdf jkl; asdf jkl; asdf jkl; asdf jkl; asdf jkl;
+
+G:NOVICE_HALL
+
+*:DAY_02
+B:KeyQuest - Jour 02 - Novice Hall: Left And Right Balance
+T:Jour 02 guidance.
+ :Arc: Novice Hall. position de base et role de chaque doigt.
+ :Objectif: position de base et role de chaque doigt.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)a&s&d&f&j&k&l&; - exercice 1
+D:asdf jkl; asdf jkl; asdf jkl; asdf jkl; asdf jkl; asdf jkl;
+I:(2)a&s&d&f&j&k&l&; - exercice 2
+D:asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj
+I:(3)a&f&s&j&d&k&l - exercice 3
+D:af sj dk fl af sj dk fl af sj dk fl af sj dk fl af sj dk fl
+I:(4)a&s&d&f&j&k&l - exercice 4
+D:sad lad ask fall sad lad ask fall sad lad ask fall sad lad ask fall
+
+G:NOVICE_HALL
+
+*:DAY_03
+B:KeyQuest - Jour 03 - Novice Hall: Finger Responsibility
+T:Jour 03 guidance.
+ :Arc: Novice Hall. position de base et role de chaque doigt.
+ :Objectif: position de base et role de chaque doigt.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)a&s&d&f&j&k&l&; - exercice 1
+D:aa ss dd ff jj kk ll ;; aa ss dd ff jj kk ll ;;
+I:(2)a&s&d&f&j&k&l&; - exercice 2
+D:as df jk l; as df jk l; as df jk l; as df jk l; as df jk l;
+I:(3)a&;&s&l&d&k&f&j - exercice 3
+D:a; sl dk fj a; sl dk fj a; sl dk fj a; sl dk fj a; sl dk fj
+I:(4)a&s&d&f&j&k&l - exercice 4
+D:ask sad fall flask ask sad fall flask ask sad fall flask
+
+G:NOVICE_HALL
+
+*:DAY_04
+B:KeyQuest - Jour 04 - Novice Hall: Rhythm Hall
+T:Jour 04 guidance.
+ :Arc: Novice Hall. position de base et role de chaque doigt.
+ :Objectif: position de base et role de chaque doigt.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)a&s&d&f&j&k&l&; - exercice 1
+D:asdf asdf jkl; jkl; asdf asdf jkl; jkl; asdf asdf jkl; jkl;
+I:(2)f&d&s&a&;&l&k&j - exercice 2
+D:fdsa fdsa ;lkj ;lkj fdsa fdsa ;lkj ;lkj fdsa fdsa ;lkj ;lkj
+I:(3)a&s&d&f&j&k&l&; - exercice 3
+D:asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj
+I:(4)a&s&d&f&j&k&l - exercice 4
+D:ask fall sad flask ask fall sad flask ask fall sad flask
+
+G:NOVICE_HALL
+
+*:DAY_05
+B:KeyQuest - Jour 05 - Novice Hall: First Words
+T:Jour 05 guidance.
+ :Arc: Novice Hall. position de base et role de chaque doigt.
+ :Objectif: position de base et role de chaque doigt.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)a&s&d&l&k - exercice 1
+D:ask sad lad ask sad lad ask sad lad ask sad lad ask sad lad
+I:(2)f&a&l&s&k - exercice 2
+D:fall flask fall flask fall flask fall flask fall flask fall flask
+I:(3)d&a&f&s&l - exercice 3
+D:dad fad salad dad fad salad dad fad salad dad fad salad
+I:(4)a&s&k&l&d&f - exercice 4
+D:ask lad fall flask ask lad fall flask ask lad fall flask
+
+G:NOVICE_HALL
+
+*:DAY_06
+B:KeyQuest - Jour 06 - Novice Hall: Repair The Stance
+T:Jour 06 guidance.
+ :Arc: Novice Hall. position de base et role de chaque doigt.
+ :Objectif: position de base et role de chaque doigt.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)a&;&s&l - exercice 1
+D:aa ;; ss ll aa ;; ss ll aa ;; ss ll aa ;; ss ll aa ;; ss ll
+I:(2)a&;&s&l - exercice 2
+D:a; s; al sl a; s; al sl a; s; al sl a; s; al sl a; s; al sl
+I:(3)s&a&d&l&f - exercice 3
+D:sad lass fall sad lass fall sad lass fall sad lass fall
+I:(4)a&s&k&l&f&d - exercice 4
+D:ask lass fall salad ask lass fall salad ask lass fall salad
+
+G:NOVICE_HALL
+
+*:DAY_07
+B:KeyQuest - Jour 07 - Novice Hall: Gatekeeper Trial
+T:Jour 07 guidance.
+ :Arc: Novice Hall. position de base et role de chaque doigt.
+ :Objectif: position de base et role de chaque doigt.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)f&j&a&s&d&k&l&; - exercice 1
+D:f j as df jk l; f j as df jk l; f j as df jk l; f j as df jk l;
+I:(2)a&s&d&f&j&k&l&; - exercice 2
+D:asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj
+I:(3)a&s&k&d&l&f - exercice 3
+D:ask sad lad fall ask sad lad fall ask sad lad fall ask sad lad fall
+I:(4)a&s&k&l&f&d - exercice 4
+D:ask lass fall salad flask ask lass fall salad flask
+
+G:NOVICE_HALL
+
+*:DAY_08
+B:KeyQuest - Jour 08 - Meadow Road: First Steps Beyond Home
+T:Jour 08 guidance.
+ :Arc: Meadow Road. atteinte de la rangee haute avec retour au repos.
+ :Objectif: atteinte de la rangee haute avec retour au repos.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)f&r&j&u - exercice 1
+D:fr ju fr ju fr ju fr ju fr ju fr ju fr ju fr ju fr ju fr ju
+I:(2)d&e&k&i - exercice 2
+D:de ki de ki de ki de ki de ki de ki de ki de ki de ki de ki
+I:(3)r&e&d&k&i - exercice 3
+D:red kid ride red kid ride red kid ride red kid ride red kid ride
+I:(4)r&u&d&e&i - exercice 4
+D:rude deer ride rude deer ride rude deer ride rude deer ride
+
+G:MEADOW_ROAD
+
+*:DAY_09
+B:KeyQuest - Jour 09 - Meadow Road: Ring Finger Reach
+T:Jour 09 guidance.
+ :Arc: Meadow Road. atteinte de la rangee haute avec retour au repos.
+ :Objectif: atteinte de la rangee haute avec retour au repos.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)s&w&l&o - exercice 1
+D:sw lo sw lo sw lo sw lo sw lo sw lo sw lo sw lo sw lo sw lo
+I:(2)w&e&o&l&d - exercice 2
+D:we old we old we old we old we old we old we old we old
+I:(3)s&l&o&w - exercice 3
+D:slow low owl slow low owl slow low owl slow low owl slow low owl
+I:(4)o&l&d&w&s - exercice 4
+D:old owl slow old owl slow old owl slow old owl slow old owl slow
+
+G:MEADOW_ROAD
+
+*:DAY_10
+B:KeyQuest - Jour 10 - Meadow Road: Index Reach
+T:Jour 10 guidance.
+ :Arc: Meadow Road. atteinte de la rangee haute avec retour au repos.
+ :Objectif: atteinte de la rangee haute avec retour au repos.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)f&t&j&y - exercice 1
+D:ft jy ft jy ft jy ft jy ft jy ft jy ft jy ft jy ft jy ft jy
+I:(2)t&r&y&e - exercice 2
+D:try yet try yet try yet try yet try yet try yet try yet try yet
+I:(3)d&r&y&t&a - exercice 3
+D:dry try yard dry try yard dry try yard dry try yard dry try yard
+I:(4)s&t&a&y&r&e&d - exercice 4
+D:stay ready steady stay ready steady stay ready steady
+
+G:MEADOW_ROAD
+
+*:DAY_11
+B:KeyQuest - Jour 11 - Meadow Road: Outer Watch
+T:Jour 11 guidance.
+ :Arc: Meadow Road. atteinte de la rangee haute avec retour au repos.
+ :Objectif: atteinte de la rangee haute avec retour au repos.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)a&q&;&p - exercice 1
+D:aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p
+I:(2)q&u&i&c&k&e&t - exercice 2
+D:quick quiet quick quiet quick quiet quick quiet quick quiet
+I:(3)p&o&i&e&u - exercice 3
+D:pop pipe pup pop pipe pup pop pipe pup pop pipe pup pop pipe pup
+I:(4)q&u&i&p&c&k&o - exercice 4
+D:quip quick pop quip quick pop quip quick pop quip quick pop
+
+G:MEADOW_ROAD
+
+*:DAY_12
+B:KeyQuest - Jour 12 - Meadow Road: Top Row Trail
+T:Jour 12 guidance.
+ :Arc: Meadow Road. atteinte de la rangee haute avec retour au repos.
+ :Objectif: atteinte de la rangee haute avec retour au repos.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)q&w&e&r&u&i&o&p - exercice 1
+D:qwer uiop qwer uiop qwer uiop qwer uiop qwer uiop qwer uiop
+I:(2)t&r&e&w&p&o&i - exercice 2
+D:trew poi poi trew trew poi poi trew trew poi poi trew
+I:(3)w&e&q&u&i&t&p&o - exercice 3
+D:we quit we pop we quit we pop we quit we pop we quit we pop
+I:(4)t&y&p&e&u&r&q&i - exercice 4
+D:type pure quiet type pure quiet type pure quiet type pure quiet
+
+G:MEADOW_ROAD
+
+*:DAY_13
+B:KeyQuest - Jour 13 - Meadow Road: First Flow
+T:Jour 13 guidance.
+ :Arc: Meadow Road. atteinte de la rangee haute avec retour au repos.
+ :Objectif: atteinte de la rangee haute avec retour au repos.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)q&u&i&e&t&r&d - exercice 1
+D:quiet rider quiet rider quiet rider quiet rider quiet rider
+I:(2)t&y&p&e&o&u&r&s - exercice 2
+D:type your story type your story type your story type your story
+I:(3)w&e&t&r&y&q&u&i&o&k - exercice 3
+D:we try quiet work we try quiet work we try quiet work
+I:(4)s&t&e&a&d&y&h&n&p&r&u - exercice 4
+D:steady hands type true steady hands type true
+
+G:MEADOW_ROAD
+
+*:DAY_14
+B:KeyQuest - Jour 14 - Meadow Road: Waystone Trial
+T:Jour 14 guidance.
+ :Arc: Meadow Road. atteinte de la rangee haute avec retour au repos.
+ :Objectif: atteinte de la rangee haute avec retour au repos.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)q&w&e&r&u&i&o&p&a&s&d&f - exercice 1
+D:qwer uiop asdf jkl; qwer uiop asdf jkl; qwer uiop asdf jkl;
+I:(2)q&u&i&e&t&y&p&r&w&o&k - exercice 2
+D:quiet type pure work quiet type pure work quiet type pure work
+I:(3)s&t&e&a&d&y&q&u&i&r - exercice 3
+D:steady quiet rider steady quiet rider steady quiet rider
+I:(4)y&o&u&r&q&i&e&t&s&a&d&h - exercice 4
+D:your quiet steady hands type true your quiet steady hands type true
+
+G:MEADOW_ROAD
+
+*:DAY_15
+B:KeyQuest - Jour 15 - River Gate: Lower Step
+T:Jour 15 guidance.
+ :Arc: River Gate. rangee basse, touches ponts et ponctuation.
+ :Objectif: rangee basse, touches ponts et ponctuation.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)d&c&k&m - exercice 1
+D:dc km dc km dc km dc km dc km dc km dc km dc km dc km dc km
+I:(2)c&o&m&e&a&l - exercice 2
+D:come calm come calm come calm come calm come calm come calm
+I:(3)m&a&k&e&c&l&o&v&s - exercice 3
+D:make calm moves make calm moves make calm moves make calm moves
+
+G:RIVER_GATE
+
+*:DAY_16
+B:KeyQuest - Jour 16 - River Gate: Valley Reach
+T:Jour 16 guidance.
+ :Arc: River Gate. rangee basse, touches ponts et ponctuation.
+ :Objectif: rangee basse, touches ponts et ponctuation.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)f&v&j&n - exercice 1
+D:fv jn fv jn fv jn fv jn fv jn fv jn fv jn fv jn fv jn fv jn
+I:(2)e&v&n&i - exercice 2
+D:even nine even nine even nine even nine even nine even nine
+I:(3)m&o&v&e&n&r&a&i&s&h - exercice 3
+D:move never vanish move never vanish move never vanish
+
+G:RIVER_GATE
+
+*:DAY_17
+B:KeyQuest - Jour 17 - River Gate: Bridge Keys
+T:Jour 17 guidance.
+ :Arc: River Gate. rangee basse, touches ponts et ponctuation.
+ :Objectif: rangee basse, touches ponts et ponctuation.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)f&g&j&h&b&n - exercice 1
+D:fg jh fb jn fg jh fb jn fg jh fb jn fg jh fb jn fg jh fb jn
+I:(2)b&r&i&n&g&h&t - exercice 2
+D:bring bright bring bright bring bright bring bright
+I:(3)b&e&g&i&n&t&h&r&d - exercice 3
+D:begin the bridge begin the bridge begin the bridge begin the bridge
+
+G:RIVER_GATE
+
+*:DAY_18
+B:KeyQuest - Jour 18 - River Gate: Comma And Period
+T:Jour 18 guidance.
+ :Arc: River Gate. rangee basse, touches ponts et ponctuation.
+ :Objectif: rangee basse, touches ponts et ponctuation.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)k&,&l&. - exercice 1
+D:k, l. k, l. k, l. k, l. k, l. k, l. k, l. k, l. k, l. k, l.
+I:(2)c&a&l&m&,&s&t&e&d&y&. - exercice 2
+D:calm, steady. calm, steady. calm, steady. calm, steady.
+I:(3)m&o&v&e&,&r&s&t&. - exercice 3
+D:move, rest. move, rest. move, rest. move, rest.
+
+G:RIVER_GATE
+
+*:DAY_19
+B:KeyQuest - Jour 19 - River Gate: Bottom Row Words
+T:Jour 19 guidance.
+ :Arc: River Gate. rangee basse, touches ponts et ponctuation.
+ :Objectif: rangee basse, touches ponts et ponctuation.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)b&r&a&v&e&m&o&c&l - exercice 1
+D:brave move calm brave move calm brave move calm brave move calm
+I:(2)n&e&v&r&b&i&g&p&a&c - exercice 2
+D:never bring panic never bring panic never bring panic
+I:(3)s&t&e&a&d&y&r&i&v&,&b&h - exercice 3
+D:steady river, brave hands. steady river, brave hands.
+
+G:RIVER_GATE
+
+*:DAY_20
+B:KeyQuest - Jour 20 - River Gate: Current Review
+T:Jour 20 guidance.
+ :Arc: River Gate. rangee basse, touches ponts et ponctuation.
+ :Objectif: rangee basse, touches ponts et ponctuation.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)q&w&e&r&a&s&d&f&z&x&c&v - exercice 1
+D:qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv
+I:(2)u&i&o&p&j&k&l&;&n&m&,&. - exercice 2
+D:uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,.
+I:(3)b&r&i&n&g&c&a&l&m&,&o&v - exercice 3
+D:bring calm, move steady. bring calm, move steady.
+
+G:RIVER_GATE
+
+*:DAY_21
+B:KeyQuest - Jour 21 - River Gate: Ferryman Trial
+T:Jour 21 guidance.
+ :Arc: River Gate. rangee basse, touches ponts et ponctuation.
+ :Objectif: rangee basse, touches ponts et ponctuation.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)a&s&d&f&q&w&e&r&z&x&c&v - exercice 1
+D:asdf qwer zxcv asdf qwer zxcv asdf qwer zxcv asdf qwer zxcv
+I:(2)j&k&l&;&u&i&o&p&n&m&,&. - exercice 2
+D:jkl; uiop nm,. jkl; uiop nm,. jkl; uiop nm,. jkl; uiop nm,.
+I:(3)n&e&v&r&p&a&i&c&,&m&o&s - exercice 3
+D:never panic, move steady. never panic, move steady.
+I:(4)b&r&a&v&e&h&n&d&s&c&o&t - exercice 4
+D:brave hands cross the quiet river. brave hands cross the quiet river.
+
+G:RIVER_GATE
+
+*:DAY_22
+B:KeyQuest - Jour 22 - Lantern Keep: Left Number Row
+T:Jour 22 guidance.
+ :Arc: Lantern Keep. rangee des chiffres et nombres pratiques.
+ :Objectif: rangee des chiffres et nombres pratiques.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)1&2&3&4 - exercice 1
+D:1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4
+I:(2)1&2&3&4 - exercice 2
+D:11 22 33 44 11 22 33 44 11 22 33 44 11 22 33 44 11 22 33 44
+I:(3)r&o&m&1&2&g&a&t&e&3&4 - exercice 3
+D:room 12 gate 34 room 12 gate 34 room 12 gate 34 room 12 gate 34
+
+G:LANTERN_KEEP
+
+*:DAY_23
+B:KeyQuest - Jour 23 - Lantern Keep: Right Number Row
+T:Jour 23 guidance.
+ :Arc: Lantern Keep. rangee des chiffres et nombres pratiques.
+ :Objectif: rangee des chiffres et nombres pratiques.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)7&8&9&0 - exercice 1
+D:7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0
+I:(2)7&8&9&0 - exercice 2
+D:77 88 99 00 77 88 99 00 77 88 99 00 77 88 99 00 77 88 99 00
+I:(3)t&o&w&e&r&7&8&p&a&h&9&0 - exercice 3
+D:tower 78 path 90 tower 78 path 90 tower 78 path 90 tower 78 path 90
+
+G:LANTERN_KEEP
+
+*:DAY_24
+B:KeyQuest - Jour 24 - Lantern Keep: Center Span
+T:Jour 24 guidance.
+ :Arc: Lantern Keep. rangee des chiffres et nombres pratiques.
+ :Objectif: rangee des chiffres et nombres pratiques.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)4&5&6&7 - exercice 1
+D:4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7
+I:(2)4&5&6&7 - exercice 2
+D:45 56 67 76 65 54 45 56 67 76 65 54 45 56 67 76 65 54
+I:(3)l&e&v&4&5&b&r&i&d&g&6&7 - exercice 3
+D:level 45 bridge 67 level 45 bridge 67 level 45 bridge 67
+
+G:LANTERN_KEEP
+
+*:DAY_25
+B:KeyQuest - Jour 25 - Lantern Keep: Counts And Codes
+T:Jour 25 guidance.
+ :Arc: Lantern Keep. rangee des chiffres et nombres pratiques.
+ :Objectif: rangee des chiffres et nombres pratiques.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)t&a&k&e&2&y&s&3&m&p - exercice 1
+D:take 2 keys and 3 maps take 2 keys and 3 maps
+I:(2)m&a&r&k&4&o&s&b&e&f&5 - exercice 2
+D:mark 4 rooms before 5 mark 4 rooms before 5 mark 4 rooms before 5
+I:(3)c&o&d&e&1&2&0&p&n&s&g&a - exercice 3
+D:code 120 opens gate 34 code 120 opens gate 34
+
+G:LANTERN_KEEP
+
+*:DAY_26
+B:KeyQuest - Jour 26 - Lantern Keep: Map Marks
+T:Jour 26 guidance.
+ :Arc: Lantern Keep. rangee des chiffres et nombres pratiques.
+ :Objectif: rangee des chiffres et nombres pratiques.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)m&a&p&1&r&o&2&h&l&3 - exercice 1
+D:map 1 room 2 hall 3 map 1 room 2 hall 3 map 1 room 2 hall 3
+I:(2)t&u&r&n&6&h&e&o&p&7 - exercice 2
+D:turn 6 then open 7 turn 6 then open 7 turn 6 then open 7
+I:(3)l&a&m&p&8&s&h&o&w&d&r&9 - exercice 3
+D:lamp 8 shows door 9 lamp 8 shows door 9 lamp 8 shows door 9
+
+G:LANTERN_KEEP
+
+*:DAY_27
+B:KeyQuest - Jour 27 - Lantern Keep: Mixed Signals
+T:Jour 27 guidance.
+ :Arc: Lantern Keep. rangee des chiffres et nombres pratiques.
+ :Objectif: rangee des chiffres et nombres pratiques.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)l&e&v&2&m&a&p&4&g&t&6 - exercice 1
+D:level 2 map 4 gate 6 level 2 map 4 gate 6 level 2 map 4 gate 6
+I:(2)p&a&t&h&8&r&o&m&1&0 - exercice 2
+D:path 8 room 10 path 8 room 10 path 8 room 10 path 8 room 10
+I:(3)s&t&e&a&d&y&h&n&r&i&g&l - exercice 3
+D:steady hands read signal 27 steady hands read signal 27
+
+G:LANTERN_KEEP
+
+*:DAY_28
+B:KeyQuest - Jour 28 - Lantern Keep: Beacon Trial
+T:Jour 28 guidance.
+ :Arc: Lantern Keep. rangee des chiffres et nombres pratiques.
+ :Objectif: rangee des chiffres et nombres pratiques.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)1&2&3&4&5&6&7&8&9&0 - exercice 1
+D:1234 567 890 1234 567 890 1234 567 890 1234 567 890 1234 567 890
+I:(2)g&a&t&e&1&2&r&o&m&3&4&p - exercice 2
+D:gate 12 room 34 path 56 gate 12 room 34 path 56
+I:(3)m&a&r&k&7&8&t&h&e&n&o&p - exercice 3
+D:mark 78 then open 90 mark 78 then open 90 mark 78 then open 90
+I:(4)t&h&e&b&a&c&o&n&p&s&l&v - exercice 4
+D:the beacon opens at level 28. the beacon opens at level 28.
+
+G:LANTERN_KEEP
+
+*:DAY_29
+B:KeyQuest - Jour 29 - Ashen Forge: Left Shift Spark
+T:Jour 29 guidance.
+ :Arc: Ashen Forge. touches Shift et majuscules.
+ :Objectif: touches Shift et majuscules.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)A&S&D&F - exercice 1
+D:A S D F A S D F A S D F A S D F A S D F A S D F A S D F A S D F
+I:(2)A&a&S&s&D&d&F&f - exercice 2
+D:A a S s D d F f A a S s D d F f A a S s D d F f A a S s D d F f
+I:(3)A&s&k&D&a&d&F&l&S&f&e - exercice 3
+D:Ask Dad Fall Safe Ask Dad Fall Safe Ask Dad Fall Safe
+
+G:ASHEN_FORGE
+
+*:DAY_30
+B:KeyQuest - Jour 30 - Ashen Forge: Right Shift Spark
+T:Jour 30 guidance.
+ :Arc: Ashen Forge. touches Shift et majuscules.
+ :Objectif: touches Shift et majuscules.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)J&K&L&H - exercice 1
+D:J K L H J K L H J K L H J K L H J K L H J K L H J K L H J K L H
+I:(2)J&j&K&k&L&l&H&h - exercice 2
+D:J j K k L l H h J j K k L l H h J j K k L l H h J j K k L l H h
+I:(3)J&o&y&K&e&L&a&k&H&i&l - exercice 3
+D:Joy Key Lake Hill Joy Key Lake Hill Joy Key Lake Hill
+
+G:ASHEN_FORGE
+
+*:DAY_31
+B:KeyQuest - Jour 31 - Ashen Forge: Capital Names
+T:Jour 31 guidance.
+ :Arc: Ashen Forge. touches Shift et majuscules.
+ :Objectif: touches Shift et majuscules.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)A&d&a&K&e&n&L&i&J&o - exercice 1
+D:Ada Ken Lia Jo Ada Ken Lia Jo Ada Ken Lia Jo Ada Ken Lia Jo
+I:(2)M&i&r&a&N&o&V&l&e&O&w&n - exercice 2
+D:Mira Nora Vale Owen Mira Nora Vale Owen Mira Nora Vale Owen
+I:(3)A&d&a&n&K&e&r - exercice 3
+D:Ada and Ken read Ada and Ken read Ada and Ken read Ada and Ken read
+
+G:ASHEN_FORGE
+
+*:DAY_32
+B:KeyQuest - Jour 32 - Ashen Forge: Sentence Starts
+T:Jour 32 guidance.
+ :Arc: Ashen Forge. touches Shift et majuscules.
+ :Objectif: touches Shift et majuscules.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)K&e&p&c&a&l&m&.&H&o&d&h - exercice 1
+D:Keep calm. Hold home. Type true.
+I:(2)T&h&e&f&o&r&g&l&w&s&.&k - exercice 2
+D:The forge glows. The key cools.
+I:(3)S&t&a&r&e&c&h&l&i&n&w&. - exercice 3
+D:Start each line with care.
+
+G:ASHEN_FORGE
+
+*:DAY_33
+B:KeyQuest - Jour 33 - Ashen Forge: Title Case
+T:Jour 33 guidance.
+ :Arc: Ashen Forge. touches Shift et majuscules.
+ :Objectif: touches Shift et majuscules.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)A&s&h&e&n&F&o&r&g - exercice 1
+D:Ashen Forge Ashen Forge Ashen Forge Ashen Forge Ashen Forge
+I:(2)S&i&l&v&e&r&K&y&Q&u&t&G - exercice 2
+D:Silver Key Quiet Gate Silver Key Quiet Gate Silver Key Quiet Gate
+I:(3)T&h&e&B&r&i&g&t&A&n&v&l - exercice 3
+D:The Bright Anvil Shapes The Silent Key
+
+G:ASHEN_FORGE
+
+*:DAY_34
+B:KeyQuest - Jour 34 - Ashen Forge: Shift Review
+T:Jour 34 guidance.
+ :Arc: Ashen Forge. touches Shift et majuscules.
+ :Objectif: touches Shift et majuscules.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)A&j&S&k&D&l&F&h - exercice 1
+D:A j S k D l F h A j S k D l F h A j S k D l F h A j S k D l F h
+I:(2)C&a&l&m&H&n&d&s&S&h&p&e - exercice 2
+D:Calm Hands Shape Bright Keys
+I:(3)A&s&t&e&a&d&y&h&n&c&l&i - exercice 3
+D:A steady hand can lift every letter.
+
+G:ASHEN_FORGE
+
+*:DAY_35
+B:KeyQuest - Jour 35 - Ashen Forge: Anvil Trial
+T:Jour 35 guidance.
+ :Arc: Ashen Forge. touches Shift et majuscules.
+ :Objectif: touches Shift et majuscules.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)A&S&D&F&J&K&L&H - exercice 1
+D:A S D F J K L H A S D F J K L H A S D F J K L H A S D F J K L H
+I:(2)A&d&a&K&e&n&M&i&r&O&w - exercice 2
+D:Ada Ken Mira Owen Ada Ken Mira Owen Ada Ken Mira Owen
+I:(3)T&h&e&A&s&n&F&o&r&g&a&p - exercice 3
+D:The Ashen Forge shapes a calm bright key.
+I:(4)H&o&l&d&h&m&e&,&t&a&p&S - exercice 4
+D:Hold home, tap Shift, and let the anvil ring.
+
+G:ASHEN_FORGE
+
+*:DAY_36
+B:KeyQuest - Jour 36 - Windspire: Even Steps
+T:Jour 36 guidance.
+ :Arc: Windspire. controle de vitesse et rythme.
+ :Objectif: controle de vitesse et rythme.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)t&a&p&r&e&s - exercice 1
+D:tap rest tap rest tap rest tap rest tap rest tap rest
+I:(2)c&a&l&m&p&e&s&t&d&y - exercice 2
+D:calm pace steady pace calm pace steady pace calm pace steady pace
+I:(3)E&v&e&r&y&s&m&a&l&t&p&k - exercice 3
+D:Every small step keeps the wind in time.
+
+G:WINDSPIRE
+
+*:DAY_37
+B:KeyQuest - Jour 37 - Windspire: Short Bursts
+T:Jour 37 guidance.
+ :Arc: Windspire. controle de vitesse et rythme.
+ :Objectif: controle de vitesse et rythme.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)f&a&s&t&o&p&c&l&m&g - exercice 1
+D:fast stop calm go fast stop calm go fast stop calm go
+I:(2)w&i&n&d&r&u&s&t&h&e - exercice 2
+D:wind runs then rests wind runs then rests wind runs then rests
+I:(3)B&u&r&s&t&f&o&a&m&e&n&, - exercice 3
+D:Burst for a moment, then return to calm hands.
+
+G:WINDSPIRE
+
+*:DAY_38
+B:KeyQuest - Jour 38 - Windspire: Long Cadence
+T:Jour 38 guidance.
+ :Arc: Windspire. controle de vitesse et rythme.
+ :Objectif: controle de vitesse et rythme.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)t&h&e&w&i&n&d&c&a&r&s&q - exercice 1
+D:the wind carries a quiet rhythm over the road
+I:(2)s&t&e&a&d&y&f&i&n&g&r&c - exercice 2
+D:steady fingers cross the high bridge with care
+I:(3)p&a&c&e&t&h&l&i&n&s&o&v - exercice 3
+D:pace the line so every word lands cleanly
+
+G:WINDSPIRE
+
+*:DAY_39
+B:KeyQuest - Jour 39 - Windspire: Alternate Pace
+T:Jour 39 guidance.
+ :Arc: Windspire. controle de vitesse et rythme.
+ :Objectif: controle de vitesse et rythme.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)s&l&o&w&q&u&i&c&k - exercice 1
+D:slow slow quick quick slow slow quick quick slow slow quick quick
+I:(2)c&a&l&m&b&r&i&g&h&t - exercice 2
+D:calm calm bright bright calm calm bright bright
+I:(3)C&h&a&n&g&e&p&c&o&l&y&w - exercice 3
+D:Change pace only when the hands stay quiet.
+
+G:WINDSPIRE
+
+*:DAY_40
+B:KeyQuest - Jour 40 - Windspire: Breath Marks
+T:Jour 40 guidance.
+ :Arc: Windspire. controle de vitesse et rythme.
+ :Objectif: controle de vitesse et rythme.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)b&r&e&a&t&h&,&y&p&u&s&. - exercice 1
+D:breathe, type, pause. breathe, type, pause.
+I:(2)s&h&o&r&t&w&i&n&d&,&l&g - exercice 2
+D:short wind, long road. calm hands, clean words.
+I:(3)L&e&t&a&c&h&o&m&s&l&w&r - exercice 3
+D:Let each comma slow the run.
+
+G:WINDSPIRE
+
+*:DAY_41
+B:KeyQuest - Jour 41 - Windspire: Gale Review
+T:Jour 41 guidance.
+ :Arc: Windspire. controle de vitesse et rythme.
+ :Objectif: controle de vitesse et rythme.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)q&w&e&r&a&s&d&f&z&x&c&v - exercice 1
+D:qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv
+I:(2)u&i&o&p&j&k&l&;&n&m&,&. - exercice 2
+D:uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,.
+I:(3)s&t&e&a&d&y&p&c&o&v&r&1 - exercice 3
+D:steady pace over 12 stones and 34 rails
+
+G:WINDSPIRE
+
+*:DAY_42
+B:KeyQuest - Jour 42 - Windspire: Gale Trial
+T:Jour 42 guidance.
+ :Arc: Windspire. controle de vitesse et rythme.
+ :Objectif: controle de vitesse et rythme.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)t&a&p&r&e&s&q&u&i&c&k&l - exercice 1
+D:tap rest quick calm tap rest quick calm tap rest quick calm
+I:(2)t&h&e&w&i&n&d&r&s&b&u&a - exercice 2
+D:the wind rises but the hands stay steady
+I:(3)q&u&i&c&k&s&t&e&p&a&r&f - exercice 3
+D:quick steps are useful only when accuracy holds
+I:(4)r&i&d&e&t&h&g&a&l&w&y&m - exercice 4
+D:ride the gale with rhythm, not panic.
+
+G:WINDSPIRE
+
+*:DAY_43
+B:KeyQuest - Jour 43 - Clockwork Citadel: Parentheses
+T:Jour 43 guidance.
+ :Arc: Clockwork Citadel. paires de programmation et crochets.
+ :Objectif: paires de programmation et crochets.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)(&) - exercice 1
+D:( ) () ( ) () ( ) () ( ) () ( ) () ( ) () ( ) () ( ) () ( ) ()
+I:(2)(&a&)&k&e&y&m&p - exercice 2
+D:(a) (key) (map) (a) (key) (map) (a) (key) (map) (a) (key) (map)
+I:(3)o&p&e&n&(&t&h&g&a&)&d&c - exercice 3
+D:open (the gate) and close (the lock)
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_44
+B:KeyQuest - Jour 44 - Clockwork Citadel: Brackets
+T:Jour 44 guidance.
+ :Arc: Clockwork Citadel. paires de programmation et crochets.
+ :Objectif: paires de programmation et crochets.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)[&] - exercice 1
+D:[ ] [] [ ] [] [ ] [] [ ] [] [ ] [] [ ] [] [ ] [] [ ] [] [ ] []
+I:(2)[&1&]&2&k&e&y - exercice 2
+D:[1] [2] [key] [1] [2] [key] [1] [2] [key] [1] [2] [key]
+I:(3)m&a&r&k&[&o&]&t&h&e&n&d - exercice 3
+D:mark [room] then read [signal]
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_45
+B:KeyQuest - Jour 45 - Clockwork Citadel: Braces
+T:Jour 45 guidance.
+ :Arc: Clockwork Citadel. paires de programmation et crochets.
+ :Objectif: paires de programmation et crochets.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1){&} - exercice 1
+D:{ } {} { } {} { } {} { } {} { } {} { } {} { } {} { } {} { } {}
+I:(2){&k&e&y&}&g&a&t&m&p - exercice 2
+D:{key} {gate} {map} {key} {gate} {map} {key} {gate} {map}
+I:(3)s&t&o&r&e&{&l&i&g&h&}&b - exercice 3
+D:store {light} before {shadow}
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_46
+B:KeyQuest - Jour 46 - Clockwork Citadel: Angle Gates
+T:Jour 46 guidance.
+ :Arc: Clockwork Citadel. paires de programmation et crochets.
+ :Objectif: paires de programmation et crochets.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)<&> - exercice 1
+D:< > <> < > <> < > <> < > <> < > <> < > <> < > <> < > <> < > <>
+I:(2)<&k&e&y&>&g&a&t&p&h - exercice 2
+D:<key> <gate> <path> <key> <gate> <path> <key> <gate> <path>
+I:(3)r&e&a&d&<&s&i&g&n&l&>&b - exercice 3
+D:read <signal> before <system> moves
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_47
+B:KeyQuest - Jour 47 - Clockwork Citadel: Nested Pairs
+T:Jour 47 guidance.
+ :Arc: Clockwork Citadel. paires de programmation et crochets.
+ :Objectif: paires de programmation et crochets.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)(&[&]&)&{&} - exercice 1
+D:([]) ({}) ([]) ({}) ([]) ({}) ([]) ({}) ([]) ({}) ([]) ({})
+I:(2)[&m&a&p&]&(&r&o&)&{&k&e - exercice 2
+D:[map](room) {key} [map](room) {key} [map](room) {key}
+I:(3)o&p&e&n&(&[&q&u&i&t&]&) - exercice 3
+D:open ([quiet]) gears with {steady} hands
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_48
+B:KeyQuest - Jour 48 - Clockwork Citadel: Gear Review
+T:Jour 48 guidance.
+ :Arc: Clockwork Citadel. paires de programmation et crochets.
+ :Objectif: paires de programmation et crochets.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)(&)&[&]&{&}&<&> - exercice 1
+D:() [] {} <> () [] {} <> () [] {} <> () [] {} <> () [] {} <>
+I:(2)g&e&a&r&[&1&]&t&u&n&s&( - exercice 2
+D:gear[1] turns (slow) while {hands} return
+I:(3)c&l&o&k&w&r&e&y&s&n&d&p - exercice 3
+D:clockwork keys need paired symbols in order
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_49
+B:KeyQuest - Jour 49 - Clockwork Citadel: Gearheart Trial
+T:Jour 49 guidance.
+ :Arc: Clockwork Citadel. paires de programmation et crochets.
+ :Objectif: paires de programmation et crochets.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)(&)&[&]&{&}&<&> - exercice 1
+D:() [] {} <> () [] {} <> () [] {} <> () [] {} <> () [] {} <>
+I:(2)o&p&e&n&(&g&a&r&)&t&h&c - exercice 2
+D:open (gear) then close [vault] with {care}
+I:(3)t&h&e&<&g&a&r&>&c&p&s&l - exercice 3
+D:the <gearheart> accepts clean paired keys
+I:(4)m&a&t&c&h&e&v&r&y&b&k&f - exercice 4
+D:match every bracket before the engine wakes.
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_50
+B:KeyQuest - Jour 50 - Starfall Library: Math Signs
+T:Jour 50 guidance.
+ :Arc: Starfall Library. symboles, operateurs et flux proche du code.
+ :Objectif: symboles, operateurs et flux proche du code.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)1&+&2&=&3 - exercice 1
+D:1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3
+I:(2)4&-&1&=&3 - exercice 2
+D:4 - 1 = 3 4 - 1 = 3 4 - 1 = 3 4 - 1 = 3 4 - 1 = 3 4 - 1 = 3
+I:(3)l&i&g&h&t&+&f&o&c&u&s&= - exercice 3
+D:light + focus = clear typing
+
+G:STARFALL_LIBRARY
+
+*:DAY_51
+B:KeyQuest - Jour 51 - Starfall Library: Slash And Star
+T:Jour 51 guidance.
+ :Arc: Starfall Library. symboles, operateurs et flux proche du code.
+ :Objectif: symboles, operateurs et flux proche du code.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)/&* - exercice 1
+D:/ * / * / * / * / * / * / * / * / * / * / * / * / * / * / * / *
+I:(2)p&a&t&h&/&m&s&r&*&k&e&y - exercice 2
+D:path / map star * key path / map star * key path / map star * key
+I:(3)r&e&a&d&/&s&l&o&w&y&n&m - exercice 3
+D:read / slowly and mark * carefully
+
+G:STARFALL_LIBRARY
+
+*:DAY_52
+B:KeyQuest - Jour 52 - Starfall Library: Quotes
+T:Jour 52 guidance.
+ :Arc: Starfall Library. symboles, operateurs et flux proche du code.
+ :Objectif: symboles, operateurs et flux proche du code.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)"&k&e&y&m&a&p - exercice 1
+D:"key" "map" "key" "map" "key" "map" "key" "map" "key" "map"
+I:(2)'&g&o&r&e&s&t - exercice 2
+D:'go' 'rest' 'go' 'rest' 'go' 'rest' 'go' 'rest' 'go' 'rest'
+I:(3)t&h&e&s&i&g&n&a&y&"&o&l - exercice 3
+D:the sign says "hold steady" before moving
+
+G:STARFALL_LIBRARY
+
+*:DAY_53
+B:KeyQuest - Jour 53 - Starfall Library: Colon Signals
+T:Jour 53 guidance.
+ :Arc: Starfall Library. symboles, operateurs et flux proche du code.
+ :Objectif: symboles, operateurs et flux proche du code.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)k&e&y&:&g&a&t&;&m&p&h - exercice 1
+D:key: gate; map: path; key: gate; map: path; key: gate; map: path;
+I:(2)n&o&t&e&:&b&r&a&h&;&y&p - exercice 2
+D:note: breathe; type: slowly; check: accuracy;
+I:(3)s&i&g&n&a&l&:&c&e&r&;&h - exercice 3
+D:signal: clear; hands: calm; route: open;
+
+G:STARFALL_LIBRARY
+
+*:DAY_54
+B:KeyQuest - Jour 54 - Starfall Library: Code Words
+T:Jour 54 guidance.
+ :Arc: Starfall Library. symboles, operateurs et flux proche du code.
+ :Objectif: symboles, operateurs et flux proche du code.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)i&f&g&a&t&e&=&o&p&n&h&y - exercice 1
+D:if gate = open then type calm words
+I:(2)c&o&u&n&t&+&f&s&-&p&a&i - exercice 2
+D:count + focus - panic = steady hands
+I:(3)p&a&t&h&/&r&o&m&k&e&y&s - exercice 3
+D:path / room / key keeps the record clear
+
+G:STARFALL_LIBRARY
+
+*:DAY_55
+B:KeyQuest - Jour 55 - Starfall Library: Archive Review
+T:Jour 55 guidance.
+ :Arc: Starfall Library. symboles, operateurs et flux proche du code.
+ :Objectif: symboles, operateurs et flux proche du code.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)1&+&2&=&3&;&4&- - exercice 1
+D:1 + 2 = 3; 4 - 1 = 3; 1 + 2 = 3; 4 - 1 = 3; 1 + 2 = 3; 4 - 1 = 3;
+I:(2)r&e&c&o&d&:&"&s&t&a&y&; - exercice 2
+D:record: "steady"; status: "clear";
+I:(3)t&h&e&a&r&c&i&v&o&p&n&s - exercice 3
+D:the archive opens when symbols stay in order
+
+G:STARFALL_LIBRARY
+
+*:DAY_56
+B:KeyQuest - Jour 56 - Starfall Library: Archivist Trial
+T:Jour 56 guidance.
+ :Arc: Starfall Library. symboles, operateurs et flux proche du code.
+ :Objectif: symboles, operateurs et flux proche du code.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)k&e&y&+&m&a&p&=&t&h&;&c - exercice 1
+D:key + map = path; path + calm = progress;
+I:(2)r&e&a&d&"&s&i&g&n&l&/&m - exercice 2
+D:read "signal" / mark "gate" / hold focus
+I:(3)i&f&r&o&m&=&c&l&e&a&t&h - exercice 3
+D:if room = clear then move slowly.
+I:(4)t&h&e&a&r&c&i&v&s&u&y&m - exercice 4
+D:the archivist trusts accurate symbols.
+
+G:STARFALL_LIBRARY
+
+*:DAY_57
+B:KeyQuest - Jour 57 - Dragon Spine: Pressure Warmup
+T:Jour 57 guidance.
+ :Arc: Dragon Spine. precision sous pression.
+ :Objectif: precision sous pression.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)h&o&l&d&c&a&m&t&y&p&e&r - exercice 1
+D:hold calm type true hold calm type true hold calm type true
+I:(2)t&h&e&r&i&d&g&s&b&u&a&n - exercice 2
+D:the ridge is high but the hands stay low
+I:(3)a&c&u&r&y&i&s&t&h&e&l&d - exercice 3
+D:accuracy is the shield before speed.
+
+G:DRAGON_SPINE
+
+*:DAY_58
+B:KeyQuest - Jour 58 - Dragon Spine: Longer Climb
+T:Jour 58 guidance.
+ :Arc: Dragon Spine. precision sous pression.
+ :Objectif: precision sous pression.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)t&h&e&d&r&a&g&o&n&i&s&b - exercice 1
+D:the dragon road rises beyond the quiet stone gate
+I:(2)e&a&c&h&r&f&u&l&w&o&d&k - exercice 2
+D:each careful word keeps the traveler on the ridge
+I:(3)f&i&n&s&h&t&e&l&a&c&y&b - exercice 3
+D:finish the line as cleanly as it began
+
+G:DRAGON_SPINE
+
+*:DAY_59
+B:KeyQuest - Jour 59 - Dragon Spine: Heat Control
+T:Jour 59 guidance.
+ :Arc: Dragon Spine. precision sous pression.
+ :Objectif: precision sous pression.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)G&a&t&e&1&2&o&p&n&s&f&r - exercice 1
+D:Gate 12 opens after Signal 34.
+I:(2)D&r&a&g&o&n&7&c&i&l&e&s - exercice 2
+D:Dragon 7 circles Tower 9 before dawn.
+I:(3)K&e&p&3&c&a&l&m&b&r&t&h - exercice 3
+D:Keep 3 calm breaths before Route 5.
+
+G:DRAGON_SPINE
+
+*:DAY_60
+B:KeyQuest - Jour 60 - Dragon Spine: No Panic
+T:Jour 60 guidance.
+ :Arc: Dragon Spine. precision sous pression.
+ :Objectif: precision sous pression.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)b&r&e&a&t&h&,&c&o&n&i&u - exercice 1
+D:breathe, correct, continue; do not chase the error.
+I:(2)t&h&e&o&p&a&b&n&d&s&,&u - exercice 2
+D:the hot path bends, but steady fingers recover.
+I:(3)s&l&o&w&c&r&e&t&i&n&b&a - exercice 3
+D:slow correction beats fast panic every time.
+
+G:DRAGON_SPINE
+
+*:DAY_61
+B:KeyQuest - Jour 61 - Dragon Spine: Focus Run
+T:Jour 61 guidance.
+ :Arc: Dragon Spine. precision sous pression.
+ :Objectif: precision sous pression.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)T&h&e&b&r&i&g&t&d&n&a&o - exercice 1
+D:The bright ridge narrows as the old dragon wakes.
+I:(2)A&c&a&l&m&t&r&v&e&d&s&h - exercice 2
+D:A calm traveler reads the wind and keeps moving.
+I:(3)E&v&e&r&y&c&l&a&n&w&o&d - exercice 3
+D:Every clean word becomes another safe step.
+
+G:DRAGON_SPINE
+
+*:DAY_62
+B:KeyQuest - Jour 62 - Dragon Spine: Wyrm Review
+T:Jour 62 guidance.
+ :Arc: Dragon Spine. precision sous pression.
+ :Objectif: precision sous pression.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)R&o&u&t&e&4&2&:&c&l&i&m - exercice 1
+D:Route 42: climb, pause, breathe, continue.
+I:(2)T&h&e&r&i&d&g&m&a&k&s&y - exercice 2
+D:The ridge marker says "steady hands survive."
+I:(3)f&o&c&u&s&+&p&a&t&i&e&n - exercice 3
+D:focus + patience = safe travel under pressure
+
+G:DRAGON_SPINE
+
+*:DAY_63
+B:KeyQuest - Jour 63 - Dragon Spine: Wyrm Trial
+T:Jour 63 guidance.
+ :Arc: Dragon Spine. precision sous pression.
+ :Objectif: precision sous pression.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)T&h&e&d&r&a&g&o&n&w&t&c - exercice 1
+D:The dragon watches each key and every pause.
+I:(2)R&o&u&t&e&6&3&i&s&n&a&r - exercice 2
+D:Route 63 is narrow, bright, and unforgiving.
+I:(3)B&r&e&a&t&h&,&y&p&c&o&v - exercice 3
+D:Breathe, type, recover; the ridge will not hurry.
+I:(4)T&h&e&w&y&r&m&i&l&d&s&t - exercice 4
+D:The wyrm yields to calm accurate hands.
+
+G:DRAGON_SPINE
+
+*:DAY_64
+B:KeyQuest - Jour 64 - Moonlit Labyrinth: Slow Repair
+T:Jour 64 guidance.
+ :Arc: Moonlit Labyrinth. recuperation des touches faibles et correction
+ :calme.
+ :Objectif: recuperation des touches faibles et correction calme.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)q&z&p&; - exercice 1
+D:q z p ; q z p ; q z p ; q z p ; q z p ; q z p ; q z p ; q z p ;
+I:(2)v&b&n&m - exercice 2
+D:v b n m v b n m v b n m v b n m v b n m v b n m v b n m v b n m
+I:(3)s&l&o&w&r&e&p&a&i&m&k&t - exercice 3
+D:slow repair makes the lost path visible
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_65
+B:KeyQuest - Jour 65 - Moonlit Labyrinth: Outer Keys
+T:Jour 65 guidance.
+ :Arc: Moonlit Labyrinth. recuperation des touches faibles et correction
+ :calme.
+ :Objectif: recuperation des touches faibles et correction calme.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)q&a&;&p - exercice 1
+D:qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p
+I:(2)z&q&p&; - exercice 2
+D:zq p; zq p; zq p; zq p; zq p; zq p; zq p; zq p; zq p; zq p;
+I:(3)q&u&i&e&t&p&a&h&s&b&y&o - exercice 3
+D:quiet paths pass beyond pale pillars
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_66
+B:KeyQuest - Jour 66 - Moonlit Labyrinth: Bottom Repair
+T:Jour 66 guidance.
+ :Arc: Moonlit Labyrinth. recuperation des touches faibles et correction
+ :calme.
+ :Objectif: recuperation des touches faibles et correction calme.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)c&v&n&m&b - exercice 1
+D:cv nm vb cv nm vb cv nm vb cv nm vb cv nm vb cv nm vb cv nm vb
+I:(2)m&o&v&e&b&r&a&n&c&l - exercice 2
+D:move brave never calm move brave never calm move brave never calm
+I:(3)t&h&e&m&a&z&b&n&d&s&l&o - exercice 3
+D:the maze bends below the home row
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_67
+B:KeyQuest - Jour 67 - Moonlit Labyrinth: Symbol Repair
+T:Jour 67 guidance.
+ :Arc: Moonlit Labyrinth. recuperation des touches faibles et correction
+ :calme.
+ :Objectif: recuperation des touches faibles et correction calme.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)(&)&[&]&{&} - exercice 1
+D:() [] {} () [] {} () [] {} () [] {} () [] {} () [] {} () [] {}
+I:(2)1&+&2&=&3 - exercice 2
+D:1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3
+I:(3)r&e&p&a&i&[&s&m&l&]&o&b - exercice 3
+D:repair [small] errors before {large} ones
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_68
+B:KeyQuest - Jour 68 - Moonlit Labyrinth: Mirror Paths
+T:Jour 68 guidance.
+ :Arc: Moonlit Labyrinth. recuperation des touches faibles et correction
+ :calme.
+ :Objectif: recuperation des touches faibles et correction calme.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)a&s&d&f&j&k&l&; - exercice 1
+D:asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj
+I:(2)q&w&e&r&u&i&o&p - exercice 2
+D:qwer rewq uiop poiu qwer rewq uiop poiu qwer rewq uiop poiu
+I:(3)l&e&f&t&p&a&h&r&i&g&b&o - exercice 3
+D:left path right path both return home
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_69
+B:KeyQuest - Jour 69 - Moonlit Labyrinth: Labyrinth Review
+T:Jour 69 guidance.
+ :Arc: Moonlit Labyrinth. recuperation des touches faibles et correction
+ :calme.
+ :Objectif: recuperation des touches faibles et correction calme.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)q&u&i&e&t&z&b&r&a&p&h&s - exercice 1
+D:quiet zebra paths puzzle every brave novice
+I:(2)s&y&m&b&o&l&,&n&u&e&r&a - exercice 2
+D:symbols, numbers, and outer keys need patience.
+I:(3)c&o&r&e&t&h&s&m&a&l&i&b - exercice 3
+D:correct the small miss before moving onward
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_70
+B:KeyQuest - Jour 70 - Moonlit Labyrinth: Minotaur Trial
+T:Jour 70 guidance.
+ :Arc: Moonlit Labyrinth. recuperation des touches faibles et correction
+ :calme.
+ :Objectif: recuperation des touches faibles et correction calme.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)q&z&p&;&v&b&n&m - exercice 1
+D:q z p ; v b n m q z p ; v b n m q z p ; v b n m q z p ; v b n m
+I:(2)q&u&i&e&t&s&y&m&b&o&l&[ - exercice 2
+D:quiet symbols [return] after {careful} repair
+I:(3)t&h&e&m&a&z&r&w&d&s&p&i - exercice 3
+D:the maze rewards patience, not panic.
+I:(4)r&e&c&o&v&a&h&k&y&n&d&l - exercice 4
+D:recover each key and leave the labyrinth.
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_71
+B:KeyQuest - Jour 71 - Obsidian Throne: Mixed Marks
+T:Jour 71 guidance.
+ :Arc: Obsidian Throne. ponctuation mixte et concentration longue.
+ :Objectif: ponctuation mixte et concentration longue.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)w&a&i&t&,&l&o&k&;&y&p&e - exercice 1
+D:wait, look; type: slowly.
+I:(2)k&e&y&:&f&o&u&n&d&,&g&a - exercice 2
+D:key: found, gate: open, path: clear.
+I:(3)t&h&e&r&o&n&i&s&d&a&k&; - exercice 3
+D:the throne is dark; the signal is bright.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_72
+B:KeyQuest - Jour 72 - Obsidian Throne: Quote Orders
+T:Jour 72 guidance.
+ :Arc: Obsidian Throne. ponctuation mixte et concentration longue.
+ :Objectif: ponctuation mixte et concentration longue.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)T&h&e&g&u&a&r&d&s&y&,&" - exercice 1
+D:The guard says, "hold the line."
+I:(2)T&h&e&m&a&p&r&d&s&,&"&t - exercice 2
+D:The map reads, "turn left, then pause."
+I:(3)S&h&e&w&i&s&p&r&,&"&a&c - exercice 3
+D:She whispers, "accuracy breaks the seal."
+
+G:OBSIDIAN_THRONE
+
+*:DAY_73
+B:KeyQuest - Jour 73 - Obsidian Throne: Long Focus
+T:Jour 73 guidance.
+ :Arc: Obsidian Throne. ponctuation mixte et concentration longue.
+ :Objectif: ponctuation mixte et concentration longue.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)B&e&y&o&n&d&t&h&b&l&a&c - exercice 1
+D:Beyond the black hall, every comma becomes a breath.
+I:(2)T&h&e&o&l&d&c&r&w&n&a&i - exercice 2
+D:The old crown waits; calm hands answer without fear.
+I:(3)A&l&o&n&g&i&e&s&y&v&r&a - exercice 3
+D:A long line is only several small clean choices.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_74
+B:KeyQuest - Jour 74 - Obsidian Throne: Clause Chains
+T:Jour 74 guidance.
+ :Arc: Obsidian Throne. ponctuation mixte et concentration longue.
+ :Objectif: ponctuation mixte et concentration longue.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)l&o&k&a&h&e&d&;&b&r&t&n - exercice 1
+D:look ahead; breathe once; type the next word.
+I:(2)t&h&e&a&l&n&r&o&w&s&;&c - exercice 2
+D:the hall narrows; the torch dims; focus remains.
+I:(3)s&l&o&w&h&a&n&d&i&;&r&u - exercice 3
+D:slow hands win; rushed hands repeat the lesson.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_75
+B:KeyQuest - Jour 75 - Obsidian Throne: Dense Review
+T:Jour 75 guidance.
+ :Arc: Obsidian Throne. ponctuation mixte et concentration longue.
+ :Objectif: ponctuation mixte et concentration longue.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)R&o&m&7&5&:&"&s&t&e&a&d - exercice 1
+D:Room 75: "steady," says the silent crown.
+I:(2)G&a&t&e&3&o&p&n&s&;&4&w - exercice 2
+D:Gate 3 opens; Gate 4 waits; Gate 5 listens.
+I:(3)c&l&e&a&r&m&k&s&,&n&w&o - exercice 3
+D:clear marks, clean words, and calm recovery.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_76
+B:KeyQuest - Jour 76 - Obsidian Throne: Crown Approach
+T:Jour 76 guidance.
+ :Arc: Obsidian Throne. ponctuation mixte et concentration longue.
+ :Objectif: ponctuation mixte et concentration longue.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)T&h&e&o&b&s&i&d&a&n&t&p - exercice 1
+D:The obsidian steps rise slowly toward the throne.
+I:(2)E&a&c&h&m&r&k&t&e&s&:&o - exercice 2
+D:Each mark matters: comma, period, colon, quote.
+I:(3)D&o&n&t&r&u&s&h&e&f&i&a - exercice 3
+D:Do not rush the final line before the crown.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_77
+B:KeyQuest - Jour 77 - Obsidian Throne: Crown Trial
+T:Jour 77 guidance.
+ :Arc: Obsidian Throne. ponctuation mixte et concentration longue.
+ :Objectif: ponctuation mixte et concentration longue.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)T&h&e&c&r&o&w&n&s&a&y&, - exercice 1
+D:The crown says, "type clearly, then continue."
+I:(2)R&o&m&7&:&p&a&u&s&e&,&b - exercice 2
+D:Room 77: pause, breathe, correct, proceed.
+I:(3)L&o&n&g&f&c&u&s&t&r&d&a - exercice 3
+D:Long focus turns dark punctuation into light.
+I:(4)T&h&e&t&r&o&n&p&s&f&a&d - exercice 4
+D:The throne opens for steady accurate hands.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_78
+B:KeyQuest - Jour 78 - Dawn Citadel: Full Keyboard Scan
+T:Jour 78 guidance.
+ :Arc: Dawn Citadel. revision de maitrise du clavier complet.
+ :Objectif: revision de maitrise du clavier complet.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)q&w&e&r&a&s&d&f&z&x&c&v - exercice 1
+D:qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv
+I:(2)u&i&o&p&j&k&l&;&n&m&,&. - exercice 2
+D:uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,.
+I:(3)1&2&3&4&5&6&7&8&9&0 - exercice 3
+D:1234 567 890 1234 567 890 1234 567 890 1234 567 890 1234 567 890
+
+G:DAWN_CITADEL
+
+*:DAY_79
+B:KeyQuest - Jour 79 - Dawn Citadel: Capital Review
+T:Jour 79 guidance.
+ :Arc: Dawn Citadel. revision de maitrise du clavier complet.
+ :Objectif: revision de maitrise du clavier complet.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)D&a&w&n&C&i&t&d&e&l&o&p - exercice 1
+D:Dawn Citadel opens Gate 79 with calm hands.
+I:(2)M&i&r&a&n&d&O&w&e&c&y&K - exercice 2
+D:Mira and Owen carry Key 12 to Tower 34.
+I:(3)E&v&e&r&y&C&a&p&i&t&l&L - exercice 3
+D:Every Capital Letter returns to home.
+
+G:DAWN_CITADEL
+
+*:DAY_80
+B:KeyQuest - Jour 80 - Dawn Citadel: Symbol Review
+T:Jour 80 guidance.
+ :Arc: Dawn Citadel. revision de maitrise du clavier complet.
+ :Objectif: revision de maitrise du clavier complet.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)(&)&[&]&{&}&<&> - exercice 1
+D:() [] {} <> () [] {} <> () [] {} <> () [] {} <> () [] {} <>
+I:(2)1&+&2&=&3&; - exercice 2
+D:1 + 2 = 3; 1 + 2 = 3; 1 + 2 = 3; 1 + 2 = 3; 1 + 2 = 3; 1 + 2 = 3;
+I:(3)r&e&c&o&d&[&a&w&n&]&=&{ - exercice 3
+D:record [dawn] = {clear} + "focus"
+
+G:DAWN_CITADEL
+
+*:DAY_81
+B:KeyQuest - Jour 81 - Dawn Citadel: Phrase Review
+T:Jour 81 guidance.
+ :Arc: Dawn Citadel. revision de maitrise du clavier complet.
+ :Objectif: revision de maitrise du clavier complet.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)t&h&e&d&a&w&n&c&i&l&g&r - exercice 1
+D:the dawn citadel gathers every lesson into one path
+I:(2)s&t&e&a&d&y&r&h&m&c&i&l - exercice 2
+D:steady rhythm carries letters, numbers, and marks
+I:(3)f&u&l&m&a&s&t&e&r&y&b&g - exercice 3
+D:full mastery begins with one clean line at a time
+
+G:DAWN_CITADEL
+
+*:DAY_82
+B:KeyQuest - Jour 82 - Dawn Citadel: Recovery Review
+T:Jour 82 guidance.
+ :Arc: Dawn Citadel. revision de maitrise du clavier complet.
+ :Objectif: revision de maitrise du clavier complet.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)q&z&p&;&v&b&n&m - exercice 1
+D:q z p ; v b n m q z p ; v b n m q z p ; v b n m q z p ; v b n m
+I:(2)r&e&c&o&v&[&q&u&i&t&l&y - exercice 2
+D:recover [quietly] after {difficult} symbols
+I:(3)t&h&e&c&i&a&d&l&r&w&s&m - exercice 3
+D:the citadel rewards calm correction
+
+G:DAWN_CITADEL
+
+*:DAY_83
+B:KeyQuest - Jour 83 - Dawn Citadel: Final Review
+T:Jour 83 guidance.
+ :Arc: Dawn Citadel. revision de maitrise du clavier complet.
+ :Objectif: revision de maitrise du clavier complet.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)G&a&t&e&8&3&o&p&n&s&w&h - exercice 1
+D:Gate 83 opens when "focus" stays bright.
+I:(2)D&a&w&n&l&i&g&h&t&c&r&o - exercice 2
+D:Dawn light crosses room 12, hall 34, and tower 56.
+I:(3)t&y&p&e&s&l&o&w&n&u&g&h - exercice 3
+D:type slowly enough to finish cleanly
+
+G:DAWN_CITADEL
+
+*:DAY_84
+B:KeyQuest - Jour 84 - Dawn Citadel: Dawn Trial
+T:Jour 84 guidance.
+ :Arc: Dawn Citadel. revision de maitrise du clavier complet.
+ :Objectif: revision de maitrise du clavier complet.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)q&w&e&r&a&s&d&f&z&x&c&v - exercice 1
+D:qwer asdf zxcv uiop qwer asdf zxcv uiop qwer asdf zxcv uiop
+I:(2)D&a&w&n&C&i&t&d&e&l&:&[ - exercice 2
+D:Dawn Citadel: [ready] = {calm} + "accuracy"
+I:(3)E&v&e&r&y&o&w&,&n&u&m&b - exercice 3
+D:Every row, number, and mark returns home.
+I:(4)T&h&e&f&i&n&a&l&g&t&p&r - exercice 4
+D:The final gate appears in the morning light.
+
+G:DAWN_CITADEL
+
+*:DAY_85
+B:KeyQuest - Jour 85 - Final Gate: First Seal
+T:Jour 85 guidance.
+ :Arc: Final Gate. quete finale de frappe integree.
+ :Objectif: quete finale de frappe integree.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)a&s&d&f&q&w&e&r&z&x&c&v - exercice 1
+D:asdf qwer zxcv 1234 asdf qwer zxcv 1234 asdf qwer zxcv 1234
+I:(2)T&h&e&f&i&r&s&t&a&l&o&p - exercice 2
+D:The first seal opens for calm accurate hands.
+I:(3)R&e&v&i&w&r&y&o&b&f&t&h - exercice 3
+D:Review every row before the final spell begins.
+I:(4)s&t&e&a&d&y&f&o&c&u&r&i - exercice 4
+D:steady focus carries the key toward silence
+
+G:FINAL_GATE
+
+*:DAY_86
+B:KeyQuest - Jour 86 - Final Gate: Second Seal
+T:Jour 86 guidance.
+ :Arc: Final Gate. quete finale de frappe integree.
+ :Objectif: quete finale de frappe integree.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)S&e&a&l&2&:&"&H&o&d&f&c - exercice 1
+D:Seal 2: "Hold focus," says the old gate.
+I:(2)K&e&y&8&6&t&u&r&n&s&l&o - exercice 2
+D:Key 86 turns slowly; the path remains clear.
+I:(3)A&B&r&i&g&h&t&H&a&n&d&y - exercice 3
+D:A Bright Hand types 3 clean lines before dawn.
+I:(4)n&u&m&b&e&r&s&a&d&k&o&y - exercice 4
+D:numbers and marks obey patient fingers
+
+G:FINAL_GATE
+
+*:DAY_87
+B:KeyQuest - Jour 87 - Final Gate: Third Seal
+T:Jour 87 guidance.
+ :Arc: Final Gate. quete finale de frappe integree.
+ :Objectif: quete finale de frappe integree.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)i&f&g&a&t&e&=&o&p&n&h&l - exercice 1
+D:if gate = open then hold steady focus
+I:(2)f&i&n&a&l&[&s&e&]&=&{&c - exercice 2
+D:final[seal] = {calm} + "accuracy"
+I:(3)p&a&t&h&/&k&e&y&l&i&g&d - exercice 3
+D:path / key / light leads beyond silence
+I:(4)p&a&i&r&e&d&s&y&m&b&o&l - exercice 4
+D:paired symbols guard the third seal
+
+G:FINAL_GATE
+
+*:DAY_88
+B:KeyQuest - Jour 88 - Final Gate: Fourth Seal
+T:Jour 88 guidance.
+ :Arc: Final Gate. quete finale de frappe integree.
+ :Objectif: quete finale de frappe integree.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)T&h&e&L&o&r&d&f&S&i&l&n - exercice 1
+D:The Lord of Silence waits beyond the final gate.
+I:(2)E&v&e&r&y&l&s&o&n&t&u&a - exercice 2
+D:Every lesson returns as one quiet line of light.
+I:(3)D&o&n&t&r&u&s&h&e&d&i&g - exercice 3
+D:Do not rush the ending; complete it cleanly.
+I:(4)a&c&u&r&y&t&n&s&h&e&l&d - exercice 4
+D:accuracy turns the last shadow into dawn
+
+G:FINAL_GATE
+
+*:DAY_89
+B:KeyQuest - Jour 89 - Final Gate: Last Camp
+T:Jour 89 guidance.
+ :Arc: Final Gate. quete finale de frappe integree.
+ :Objectif: quete finale de frappe integree.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)N&o&v&i&c&e&h&a&n&d&s&b - exercice 1
+D:Novice hands became steady hands over many days.
+I:(2)R&o&w&s&,&n&u&m&b&e&r&y - exercice 2
+D:Rows, numbers, symbols, and stories gather here.
+I:(3)B&r&e&a&t&h&o&n&c&b&f&i - exercice 3
+D:Breathe once before the final spell is typed.
+I:(4)t&h&e&l&a&s&c&m&p&i&q&u - exercice 4
+D:the last camp is quiet, bright, and ready
+
+G:FINAL_GATE
+
+*:DAY_90
+B:KeyQuest - Jour 90 - Final Gate: Last Spell Trial
+T:Jour 90 guidance.
+ :Arc: Final Gate. quete finale de frappe integree.
+ :Objectif: quete finale de frappe integree.
+ :Priorite a la precision; la vitesse vient apres une ligne propre.
+I:(1)T&h&e&f&i&n&a&l&g&t&o&p - exercice 1
+D:The final gate opens when every key returns home.
+I:(2)K&e&y&Q&u&s&t&D&a&9&0&: - exercice 2
+D:KeyQuest Day 90: "Accuracy breaks the silence."
+I:(3)i&f&o&c&u&s&=&t&e&a&d&y - exercice 3
+D:if focus = steady then the last spell shines
+I:(4)T&h&e&L&o&r&d&f&S&i&l&n - exercice 4
+D:The Lord of Silence falls to calm typing.
+
+G:FINAL_GATE
+
+*:ABOUT
+B:A propos du voyage de frappe KeyQuest
+T:Ce script GNU Typist adapte KeyQuest en voyage de frappe de 90 jours.
+ :Les lignes D: a taper restent en anglais et identiques dans chaque langue.
+ :Seuls les menus, titres et explications sont localises.
+ :Travaille un jour par session et repete quand la precision baisse.
+G:MENU
+*:EXIT
+B:Merci de vous etre entraine avec KeyQuest.
+T:Pratique un peu chaque jour. La precision ouvre la porte finale.
+X:

--- a/keyquest.ja.typ
+++ b/keyquest.ja.typ
@@ -1,0 +1,1581 @@
+*:MENU
+M: "KeyQuest タイピングの旅"
+ :NOVICE_HALL  "Novice Hall"
+ :MEADOW_ROAD  "Meadow Road"
+ :RIVER_GATE  "River Gate"
+ :LANTERN_KEEP  "Lantern Keep"
+ :ASHEN_FORGE  "Ashen Forge"
+ :WINDSPIRE  "Windspire"
+ :CLOCKWORK_CITADEL  "Clockwork Citadel"
+ :STARFALL_LIBRARY  "Starfall Library"
+ :DRAGON_SPINE  "Dragon Spine"
+ :MOONLIT_LABYRINTH  "Moonlit Labyrinth"
+ :OBSIDIAN_THRONE  "Obsidian Throne"
+ :DAWN_CITADEL  "Dawn Citadel"
+ :FINAL_GATE  "Final Gate"
+ :ABOUT  "このスクリプトについて"
+ :EXIT  "終了"
+
+*:NOVICE_HALL
+M: "Novice Hall"
+ :DAY_01  "Day 01: Home Position"
+ :DAY_02  "Day 02: Left And Right Balance"
+ :DAY_03  "Day 03: Finger Responsibility"
+ :DAY_04  "Day 04: Rhythm Hall"
+ :DAY_05  "Day 05: First Words"
+ :DAY_06  "Day 06: Repair The Stance"
+ :DAY_07  "Day 07: Gatekeeper Trial"
+ :MENU  "アークメニューに戻る"
+
+*:MEADOW_ROAD
+M: "Meadow Road"
+ :DAY_08  "Day 08: First Steps Beyond Home"
+ :DAY_09  "Day 09: Ring Finger Reach"
+ :DAY_10  "Day 10: Index Reach"
+ :DAY_11  "Day 11: Outer Watch"
+ :DAY_12  "Day 12: Top Row Trail"
+ :DAY_13  "Day 13: First Flow"
+ :DAY_14  "Day 14: Waystone Trial"
+ :MENU  "アークメニューに戻る"
+
+*:RIVER_GATE
+M: "River Gate"
+ :DAY_15  "Day 15: Lower Step"
+ :DAY_16  "Day 16: Valley Reach"
+ :DAY_17  "Day 17: Bridge Keys"
+ :DAY_18  "Day 18: Comma And Period"
+ :DAY_19  "Day 19: Bottom Row Words"
+ :DAY_20  "Day 20: Current Review"
+ :DAY_21  "Day 21: Ferryman Trial"
+ :MENU  "アークメニューに戻る"
+
+*:LANTERN_KEEP
+M: "Lantern Keep"
+ :DAY_22  "Day 22: Left Number Row"
+ :DAY_23  "Day 23: Right Number Row"
+ :DAY_24  "Day 24: Center Span"
+ :DAY_25  "Day 25: Counts And Codes"
+ :DAY_26  "Day 26: Map Marks"
+ :DAY_27  "Day 27: Mixed Signals"
+ :DAY_28  "Day 28: Beacon Trial"
+ :MENU  "アークメニューに戻る"
+
+*:ASHEN_FORGE
+M: "Ashen Forge"
+ :DAY_29  "Day 29: Left Shift Spark"
+ :DAY_30  "Day 30: Right Shift Spark"
+ :DAY_31  "Day 31: Capital Names"
+ :DAY_32  "Day 32: Sentence Starts"
+ :DAY_33  "Day 33: Title Case"
+ :DAY_34  "Day 34: Shift Review"
+ :DAY_35  "Day 35: Anvil Trial"
+ :MENU  "アークメニューに戻る"
+
+*:WINDSPIRE
+M: "Windspire"
+ :DAY_36  "Day 36: Even Steps"
+ :DAY_37  "Day 37: Short Bursts"
+ :DAY_38  "Day 38: Long Cadence"
+ :DAY_39  "Day 39: Alternate Pace"
+ :DAY_40  "Day 40: Breath Marks"
+ :DAY_41  "Day 41: Gale Review"
+ :DAY_42  "Day 42: Gale Trial"
+ :MENU  "アークメニューに戻る"
+
+*:CLOCKWORK_CITADEL
+M: "Clockwork Citadel"
+ :DAY_43  "Day 43: Parentheses"
+ :DAY_44  "Day 44: Brackets"
+ :DAY_45  "Day 45: Braces"
+ :DAY_46  "Day 46: Angle Gates"
+ :DAY_47  "Day 47: Nested Pairs"
+ :DAY_48  "Day 48: Gear Review"
+ :DAY_49  "Day 49: Gearheart Trial"
+ :MENU  "アークメニューに戻る"
+
+*:STARFALL_LIBRARY
+M: "Starfall Library"
+ :DAY_50  "Day 50: Math Signs"
+ :DAY_51  "Day 51: Slash And Star"
+ :DAY_52  "Day 52: Quotes"
+ :DAY_53  "Day 53: Colon Signals"
+ :DAY_54  "Day 54: Code Words"
+ :DAY_55  "Day 55: Archive Review"
+ :DAY_56  "Day 56: Archivist Trial"
+ :MENU  "アークメニューに戻る"
+
+*:DRAGON_SPINE
+M: "Dragon Spine"
+ :DAY_57  "Day 57: Pressure Warmup"
+ :DAY_58  "Day 58: Longer Climb"
+ :DAY_59  "Day 59: Heat Control"
+ :DAY_60  "Day 60: No Panic"
+ :DAY_61  "Day 61: Focus Run"
+ :DAY_62  "Day 62: Wyrm Review"
+ :DAY_63  "Day 63: Wyrm Trial"
+ :MENU  "アークメニューに戻る"
+
+*:MOONLIT_LABYRINTH
+M: "Moonlit Labyrinth"
+ :DAY_64  "Day 64: Slow Repair"
+ :DAY_65  "Day 65: Outer Keys"
+ :DAY_66  "Day 66: Bottom Repair"
+ :DAY_67  "Day 67: Symbol Repair"
+ :DAY_68  "Day 68: Mirror Paths"
+ :DAY_69  "Day 69: Labyrinth Review"
+ :DAY_70  "Day 70: Minotaur Trial"
+ :MENU  "アークメニューに戻る"
+
+*:OBSIDIAN_THRONE
+M: "Obsidian Throne"
+ :DAY_71  "Day 71: Mixed Marks"
+ :DAY_72  "Day 72: Quote Orders"
+ :DAY_73  "Day 73: Long Focus"
+ :DAY_74  "Day 74: Clause Chains"
+ :DAY_75  "Day 75: Dense Review"
+ :DAY_76  "Day 76: Crown Approach"
+ :DAY_77  "Day 77: Crown Trial"
+ :MENU  "アークメニューに戻る"
+
+*:DAWN_CITADEL
+M: "Dawn Citadel"
+ :DAY_78  "Day 78: Full Keyboard Scan"
+ :DAY_79  "Day 79: Capital Review"
+ :DAY_80  "Day 80: Symbol Review"
+ :DAY_81  "Day 81: Phrase Review"
+ :DAY_82  "Day 82: Recovery Review"
+ :DAY_83  "Day 83: Final Review"
+ :DAY_84  "Day 84: Dawn Trial"
+ :MENU  "アークメニューに戻る"
+
+*:FINAL_GATE
+M: "Final Gate"
+ :DAY_85  "Day 85: First Seal"
+ :DAY_86  "Day 86: Second Seal"
+ :DAY_87  "Day 87: Third Seal"
+ :DAY_88  "Day 88: Fourth Seal"
+ :DAY_89  "Day 89: Last Camp"
+ :DAY_90  "Day 90: Last Spell Trial"
+ :MENU  "アークメニューに戻る"
+
+*:DAY_01
+B:KeyQuest - Day 01 - Novice Hall: Home Position
+T:Day 01 の案内です。
+ :アーク: Novice Hall. ホームポジションと指の担当を固める訓練場.
+ :重点: ホームポジションと指の担当を固める訓練場.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)f&j - ドリル 1
+D:f j f j f j f j f j f j f j f j
+I:(2)f&j - ドリル 2
+D:ff jj ff jj ff jj ff jj ff jj ff jj ff jj ff jj
+I:(3)f&j - ドリル 3
+D:fj jf fj jf fj jf fj jf fj jf fj jf fj jf fj jf
+I:(4)a&s&d&f&j&k&l&; - ドリル 4
+D:asdf jkl; asdf jkl; asdf jkl; asdf jkl; asdf jkl; asdf jkl;
+
+G:NOVICE_HALL
+
+*:DAY_02
+B:KeyQuest - Day 02 - Novice Hall: Left And Right Balance
+T:Day 02 の案内です。
+ :アーク: Novice Hall. ホームポジションと指の担当を固める訓練場.
+ :重点: ホームポジションと指の担当を固める訓練場.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)a&s&d&f&j&k&l&; - ドリル 1
+D:asdf jkl; asdf jkl; asdf jkl; asdf jkl; asdf jkl; asdf jkl;
+I:(2)a&s&d&f&j&k&l&; - ドリル 2
+D:asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj
+I:(3)a&f&s&j&d&k&l - ドリル 3
+D:af sj dk fl af sj dk fl af sj dk fl af sj dk fl af sj dk fl
+I:(4)a&s&d&f&j&k&l - ドリル 4
+D:sad lad ask fall sad lad ask fall sad lad ask fall sad lad ask fall
+
+G:NOVICE_HALL
+
+*:DAY_03
+B:KeyQuest - Day 03 - Novice Hall: Finger Responsibility
+T:Day 03 の案内です。
+ :アーク: Novice Hall. ホームポジションと指の担当を固める訓練場.
+ :重点: ホームポジションと指の担当を固める訓練場.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)a&s&d&f&j&k&l&; - ドリル 1
+D:aa ss dd ff jj kk ll ;; aa ss dd ff jj kk ll ;;
+I:(2)a&s&d&f&j&k&l&; - ドリル 2
+D:as df jk l; as df jk l; as df jk l; as df jk l; as df jk l;
+I:(3)a&;&s&l&d&k&f&j - ドリル 3
+D:a; sl dk fj a; sl dk fj a; sl dk fj a; sl dk fj a; sl dk fj
+I:(4)a&s&d&f&j&k&l - ドリル 4
+D:ask sad fall flask ask sad fall flask ask sad fall flask
+
+G:NOVICE_HALL
+
+*:DAY_04
+B:KeyQuest - Day 04 - Novice Hall: Rhythm Hall
+T:Day 04 の案内です。
+ :アーク: Novice Hall. ホームポジションと指の担当を固める訓練場.
+ :重点: ホームポジションと指の担当を固める訓練場.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)a&s&d&f&j&k&l&; - ドリル 1
+D:asdf asdf jkl; jkl; asdf asdf jkl; jkl; asdf asdf jkl; jkl;
+I:(2)f&d&s&a&;&l&k&j - ドリル 2
+D:fdsa fdsa ;lkj ;lkj fdsa fdsa ;lkj ;lkj fdsa fdsa ;lkj ;lkj
+I:(3)a&s&d&f&j&k&l&; - ドリル 3
+D:asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj
+I:(4)a&s&d&f&j&k&l - ドリル 4
+D:ask fall sad flask ask fall sad flask ask fall sad flask
+
+G:NOVICE_HALL
+
+*:DAY_05
+B:KeyQuest - Day 05 - Novice Hall: First Words
+T:Day 05 の案内です。
+ :アーク: Novice Hall. ホームポジションと指の担当を固める訓練場.
+ :重点: ホームポジションと指の担当を固める訓練場.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)a&s&d&l&k - ドリル 1
+D:ask sad lad ask sad lad ask sad lad ask sad lad ask sad lad
+I:(2)f&a&l&s&k - ドリル 2
+D:fall flask fall flask fall flask fall flask fall flask fall flask
+I:(3)d&a&f&s&l - ドリル 3
+D:dad fad salad dad fad salad dad fad salad dad fad salad
+I:(4)a&s&k&l&d&f - ドリル 4
+D:ask lad fall flask ask lad fall flask ask lad fall flask
+
+G:NOVICE_HALL
+
+*:DAY_06
+B:KeyQuest - Day 06 - Novice Hall: Repair The Stance
+T:Day 06 の案内です。
+ :アーク: Novice Hall. ホームポジションと指の担当を固める訓練場.
+ :重点: ホームポジションと指の担当を固める訓練場.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)a&;&s&l - ドリル 1
+D:aa ;; ss ll aa ;; ss ll aa ;; ss ll aa ;; ss ll aa ;; ss ll
+I:(2)a&;&s&l - ドリル 2
+D:a; s; al sl a; s; al sl a; s; al sl a; s; al sl a; s; al sl
+I:(3)s&a&d&l&f - ドリル 3
+D:sad lass fall sad lass fall sad lass fall sad lass fall
+I:(4)a&s&k&l&f&d - ドリル 4
+D:ask lass fall salad ask lass fall salad ask lass fall salad
+
+G:NOVICE_HALL
+
+*:DAY_07
+B:KeyQuest - Day 07 - Novice Hall: Gatekeeper Trial
+T:Day 07 の案内です。
+ :アーク: Novice Hall. ホームポジションと指の担当を固める訓練場.
+ :重点: ホームポジションと指の担当を固める訓練場.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)f&j&a&s&d&k&l&; - ドリル 1
+D:f j as df jk l; f j as df jk l; f j as df jk l; f j as df jk l;
+I:(2)a&s&d&f&j&k&l&; - ドリル 2
+D:asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj
+I:(3)a&s&k&d&l&f - ドリル 3
+D:ask sad lad fall ask sad lad fall ask sad lad fall ask sad lad fall
+I:(4)a&s&k&l&f&d - ドリル 4
+D:ask lass fall salad flask ask lass fall salad flask
+
+G:NOVICE_HALL
+
+*:DAY_08
+B:KeyQuest - Day 08 - Meadow Road: First Steps Beyond Home
+T:Day 08 の案内です。
+ :アーク: Meadow Road. ホームへ戻りながら上段へ手を伸ばす道.
+ :重点: ホームへ戻りながら上段へ手を伸ばす道.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)f&r&j&u - ドリル 1
+D:fr ju fr ju fr ju fr ju fr ju fr ju fr ju fr ju fr ju fr ju
+I:(2)d&e&k&i - ドリル 2
+D:de ki de ki de ki de ki de ki de ki de ki de ki de ki de ki
+I:(3)r&e&d&k&i - ドリル 3
+D:red kid ride red kid ride red kid ride red kid ride red kid ride
+I:(4)r&u&d&e&i - ドリル 4
+D:rude deer ride rude deer ride rude deer ride rude deer ride
+
+G:MEADOW_ROAD
+
+*:DAY_09
+B:KeyQuest - Day 09 - Meadow Road: Ring Finger Reach
+T:Day 09 の案内です。
+ :アーク: Meadow Road. ホームへ戻りながら上段へ手を伸ばす道.
+ :重点: ホームへ戻りながら上段へ手を伸ばす道.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)s&w&l&o - ドリル 1
+D:sw lo sw lo sw lo sw lo sw lo sw lo sw lo sw lo sw lo sw lo
+I:(2)w&e&o&l&d - ドリル 2
+D:we old we old we old we old we old we old we old we old
+I:(3)s&l&o&w - ドリル 3
+D:slow low owl slow low owl slow low owl slow low owl slow low owl
+I:(4)o&l&d&w&s - ドリル 4
+D:old owl slow old owl slow old owl slow old owl slow old owl slow
+
+G:MEADOW_ROAD
+
+*:DAY_10
+B:KeyQuest - Day 10 - Meadow Road: Index Reach
+T:Day 10 の案内です。
+ :アーク: Meadow Road. ホームへ戻りながら上段へ手を伸ばす道.
+ :重点: ホームへ戻りながら上段へ手を伸ばす道.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)f&t&j&y - ドリル 1
+D:ft jy ft jy ft jy ft jy ft jy ft jy ft jy ft jy ft jy ft jy
+I:(2)t&r&y&e - ドリル 2
+D:try yet try yet try yet try yet try yet try yet try yet try yet
+I:(3)d&r&y&t&a - ドリル 3
+D:dry try yard dry try yard dry try yard dry try yard dry try yard
+I:(4)s&t&a&y&r&e&d - ドリル 4
+D:stay ready steady stay ready steady stay ready steady
+
+G:MEADOW_ROAD
+
+*:DAY_11
+B:KeyQuest - Day 11 - Meadow Road: Outer Watch
+T:Day 11 の案内です。
+ :アーク: Meadow Road. ホームへ戻りながら上段へ手を伸ばす道.
+ :重点: ホームへ戻りながら上段へ手を伸ばす道.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)a&q&;&p - ドリル 1
+D:aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p aq ;p
+I:(2)q&u&i&c&k&e&t - ドリル 2
+D:quick quiet quick quiet quick quiet quick quiet quick quiet
+I:(3)p&o&i&e&u - ドリル 3
+D:pop pipe pup pop pipe pup pop pipe pup pop pipe pup pop pipe pup
+I:(4)q&u&i&p&c&k&o - ドリル 4
+D:quip quick pop quip quick pop quip quick pop quip quick pop
+
+G:MEADOW_ROAD
+
+*:DAY_12
+B:KeyQuest - Day 12 - Meadow Road: Top Row Trail
+T:Day 12 の案内です。
+ :アーク: Meadow Road. ホームへ戻りながら上段へ手を伸ばす道.
+ :重点: ホームへ戻りながら上段へ手を伸ばす道.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)q&w&e&r&u&i&o&p - ドリル 1
+D:qwer uiop qwer uiop qwer uiop qwer uiop qwer uiop qwer uiop
+I:(2)t&r&e&w&p&o&i - ドリル 2
+D:trew poi poi trew trew poi poi trew trew poi poi trew
+I:(3)w&e&q&u&i&t&p&o - ドリル 3
+D:we quit we pop we quit we pop we quit we pop we quit we pop
+I:(4)t&y&p&e&u&r&q&i - ドリル 4
+D:type pure quiet type pure quiet type pure quiet type pure quiet
+
+G:MEADOW_ROAD
+
+*:DAY_13
+B:KeyQuest - Day 13 - Meadow Road: First Flow
+T:Day 13 の案内です。
+ :アーク: Meadow Road. ホームへ戻りながら上段へ手を伸ばす道.
+ :重点: ホームへ戻りながら上段へ手を伸ばす道.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)q&u&i&e&t&r&d - ドリル 1
+D:quiet rider quiet rider quiet rider quiet rider quiet rider
+I:(2)t&y&p&e&o&u&r&s - ドリル 2
+D:type your story type your story type your story type your story
+I:(3)w&e&t&r&y&q&u&i&o&k - ドリル 3
+D:we try quiet work we try quiet work we try quiet work
+I:(4)s&t&e&a&d&y&h&n&p&r&u - ドリル 4
+D:steady hands type true steady hands type true
+
+G:MEADOW_ROAD
+
+*:DAY_14
+B:KeyQuest - Day 14 - Meadow Road: Waystone Trial
+T:Day 14 の案内です。
+ :アーク: Meadow Road. ホームへ戻りながら上段へ手を伸ばす道.
+ :重点: ホームへ戻りながら上段へ手を伸ばす道.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)q&w&e&r&u&i&o&p&a&s&d&f - ドリル 1
+D:qwer uiop asdf jkl; qwer uiop asdf jkl; qwer uiop asdf jkl;
+I:(2)q&u&i&e&t&y&p&r&w&o&k - ドリル 2
+D:quiet type pure work quiet type pure work quiet type pure work
+I:(3)s&t&e&a&d&y&q&u&i&r - ドリル 3
+D:steady quiet rider steady quiet rider steady quiet rider
+I:(4)y&o&u&r&q&i&e&t&s&a&d&h - ドリル 4
+D:your quiet steady hands type true your quiet steady hands type true
+
+G:MEADOW_ROAD
+
+*:DAY_15
+B:KeyQuest - Day 15 - River Gate: Lower Step
+T:Day 15 の案内です。
+ :アーク: River Gate. 下段、橋渡しキー、句読点を練習する川門.
+ :重点: 下段、橋渡しキー、句読点を練習する川門.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)d&c&k&m - ドリル 1
+D:dc km dc km dc km dc km dc km dc km dc km dc km dc km dc km
+I:(2)c&o&m&e&a&l - ドリル 2
+D:come calm come calm come calm come calm come calm come calm
+I:(3)m&a&k&e&c&l&o&v&s - ドリル 3
+D:make calm moves make calm moves make calm moves make calm moves
+
+G:RIVER_GATE
+
+*:DAY_16
+B:KeyQuest - Day 16 - River Gate: Valley Reach
+T:Day 16 の案内です。
+ :アーク: River Gate. 下段、橋渡しキー、句読点を練習する川門.
+ :重点: 下段、橋渡しキー、句読点を練習する川門.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)f&v&j&n - ドリル 1
+D:fv jn fv jn fv jn fv jn fv jn fv jn fv jn fv jn fv jn fv jn
+I:(2)e&v&n&i - ドリル 2
+D:even nine even nine even nine even nine even nine even nine
+I:(3)m&o&v&e&n&r&a&i&s&h - ドリル 3
+D:move never vanish move never vanish move never vanish
+
+G:RIVER_GATE
+
+*:DAY_17
+B:KeyQuest - Day 17 - River Gate: Bridge Keys
+T:Day 17 の案内です。
+ :アーク: River Gate. 下段、橋渡しキー、句読点を練習する川門.
+ :重点: 下段、橋渡しキー、句読点を練習する川門.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)f&g&j&h&b&n - ドリル 1
+D:fg jh fb jn fg jh fb jn fg jh fb jn fg jh fb jn fg jh fb jn
+I:(2)b&r&i&n&g&h&t - ドリル 2
+D:bring bright bring bright bring bright bring bright
+I:(3)b&e&g&i&n&t&h&r&d - ドリル 3
+D:begin the bridge begin the bridge begin the bridge begin the bridge
+
+G:RIVER_GATE
+
+*:DAY_18
+B:KeyQuest - Day 18 - River Gate: Comma And Period
+T:Day 18 の案内です。
+ :アーク: River Gate. 下段、橋渡しキー、句読点を練習する川門.
+ :重点: 下段、橋渡しキー、句読点を練習する川門.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)k&,&l&. - ドリル 1
+D:k, l. k, l. k, l. k, l. k, l. k, l. k, l. k, l. k, l. k, l.
+I:(2)c&a&l&m&,&s&t&e&d&y&. - ドリル 2
+D:calm, steady. calm, steady. calm, steady. calm, steady.
+I:(3)m&o&v&e&,&r&s&t&. - ドリル 3
+D:move, rest. move, rest. move, rest. move, rest.
+
+G:RIVER_GATE
+
+*:DAY_19
+B:KeyQuest - Day 19 - River Gate: Bottom Row Words
+T:Day 19 の案内です。
+ :アーク: River Gate. 下段、橋渡しキー、句読点を練習する川門.
+ :重点: 下段、橋渡しキー、句読点を練習する川門.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)b&r&a&v&e&m&o&c&l - ドリル 1
+D:brave move calm brave move calm brave move calm brave move calm
+I:(2)n&e&v&r&b&i&g&p&a&c - ドリル 2
+D:never bring panic never bring panic never bring panic
+I:(3)s&t&e&a&d&y&r&i&v&,&b&h - ドリル 3
+D:steady river, brave hands. steady river, brave hands.
+
+G:RIVER_GATE
+
+*:DAY_20
+B:KeyQuest - Day 20 - River Gate: Current Review
+T:Day 20 の案内です。
+ :アーク: River Gate. 下段、橋渡しキー、句読点を練習する川門.
+ :重点: 下段、橋渡しキー、句読点を練習する川門.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)q&w&e&r&a&s&d&f&z&x&c&v - ドリル 1
+D:qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv
+I:(2)u&i&o&p&j&k&l&;&n&m&,&. - ドリル 2
+D:uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,.
+I:(3)b&r&i&n&g&c&a&l&m&,&o&v - ドリル 3
+D:bring calm, move steady. bring calm, move steady.
+
+G:RIVER_GATE
+
+*:DAY_21
+B:KeyQuest - Day 21 - River Gate: Ferryman Trial
+T:Day 21 の案内です。
+ :アーク: River Gate. 下段、橋渡しキー、句読点を練習する川門.
+ :重点: 下段、橋渡しキー、句読点を練習する川門.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)a&s&d&f&q&w&e&r&z&x&c&v - ドリル 1
+D:asdf qwer zxcv asdf qwer zxcv asdf qwer zxcv asdf qwer zxcv
+I:(2)j&k&l&;&u&i&o&p&n&m&,&. - ドリル 2
+D:jkl; uiop nm,. jkl; uiop nm,. jkl; uiop nm,. jkl; uiop nm,.
+I:(3)n&e&v&r&p&a&i&c&,&m&o&s - ドリル 3
+D:never panic, move steady. never panic, move steady.
+I:(4)b&r&a&v&e&h&n&d&s&c&o&t - ドリル 4
+D:brave hands cross the quiet river. brave hands cross the quiet river.
+
+G:RIVER_GATE
+
+*:DAY_22
+B:KeyQuest - Day 22 - Lantern Keep: Left Number Row
+T:Day 22 の案内です。
+ :アーク: Lantern Keep. 数字段と実用的な番号入力を練習する灯台.
+ :重点: 数字段と実用的な番号入力を練習する灯台.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)1&2&3&4 - ドリル 1
+D:1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4 1 2 3 4
+I:(2)1&2&3&4 - ドリル 2
+D:11 22 33 44 11 22 33 44 11 22 33 44 11 22 33 44 11 22 33 44
+I:(3)r&o&m&1&2&g&a&t&e&3&4 - ドリル 3
+D:room 12 gate 34 room 12 gate 34 room 12 gate 34 room 12 gate 34
+
+G:LANTERN_KEEP
+
+*:DAY_23
+B:KeyQuest - Day 23 - Lantern Keep: Right Number Row
+T:Day 23 の案内です。
+ :アーク: Lantern Keep. 数字段と実用的な番号入力を練習する灯台.
+ :重点: 数字段と実用的な番号入力を練習する灯台.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)7&8&9&0 - ドリル 1
+D:7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0 7 8 9 0
+I:(2)7&8&9&0 - ドリル 2
+D:77 88 99 00 77 88 99 00 77 88 99 00 77 88 99 00 77 88 99 00
+I:(3)t&o&w&e&r&7&8&p&a&h&9&0 - ドリル 3
+D:tower 78 path 90 tower 78 path 90 tower 78 path 90 tower 78 path 90
+
+G:LANTERN_KEEP
+
+*:DAY_24
+B:KeyQuest - Day 24 - Lantern Keep: Center Span
+T:Day 24 の案内です。
+ :アーク: Lantern Keep. 数字段と実用的な番号入力を練習する灯台.
+ :重点: 数字段と実用的な番号入力を練習する灯台.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)4&5&6&7 - ドリル 1
+D:4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7 4 5 6 7
+I:(2)4&5&6&7 - ドリル 2
+D:45 56 67 76 65 54 45 56 67 76 65 54 45 56 67 76 65 54
+I:(3)l&e&v&4&5&b&r&i&d&g&6&7 - ドリル 3
+D:level 45 bridge 67 level 45 bridge 67 level 45 bridge 67
+
+G:LANTERN_KEEP
+
+*:DAY_25
+B:KeyQuest - Day 25 - Lantern Keep: Counts And Codes
+T:Day 25 の案内です。
+ :アーク: Lantern Keep. 数字段と実用的な番号入力を練習する灯台.
+ :重点: 数字段と実用的な番号入力を練習する灯台.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)t&a&k&e&2&y&s&3&m&p - ドリル 1
+D:take 2 keys and 3 maps take 2 keys and 3 maps
+I:(2)m&a&r&k&4&o&s&b&e&f&5 - ドリル 2
+D:mark 4 rooms before 5 mark 4 rooms before 5 mark 4 rooms before 5
+I:(3)c&o&d&e&1&2&0&p&n&s&g&a - ドリル 3
+D:code 120 opens gate 34 code 120 opens gate 34
+
+G:LANTERN_KEEP
+
+*:DAY_26
+B:KeyQuest - Day 26 - Lantern Keep: Map Marks
+T:Day 26 の案内です。
+ :アーク: Lantern Keep. 数字段と実用的な番号入力を練習する灯台.
+ :重点: 数字段と実用的な番号入力を練習する灯台.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)m&a&p&1&r&o&2&h&l&3 - ドリル 1
+D:map 1 room 2 hall 3 map 1 room 2 hall 3 map 1 room 2 hall 3
+I:(2)t&u&r&n&6&h&e&o&p&7 - ドリル 2
+D:turn 6 then open 7 turn 6 then open 7 turn 6 then open 7
+I:(3)l&a&m&p&8&s&h&o&w&d&r&9 - ドリル 3
+D:lamp 8 shows door 9 lamp 8 shows door 9 lamp 8 shows door 9
+
+G:LANTERN_KEEP
+
+*:DAY_27
+B:KeyQuest - Day 27 - Lantern Keep: Mixed Signals
+T:Day 27 の案内です。
+ :アーク: Lantern Keep. 数字段と実用的な番号入力を練習する灯台.
+ :重点: 数字段と実用的な番号入力を練習する灯台.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)l&e&v&2&m&a&p&4&g&t&6 - ドリル 1
+D:level 2 map 4 gate 6 level 2 map 4 gate 6 level 2 map 4 gate 6
+I:(2)p&a&t&h&8&r&o&m&1&0 - ドリル 2
+D:path 8 room 10 path 8 room 10 path 8 room 10 path 8 room 10
+I:(3)s&t&e&a&d&y&h&n&r&i&g&l - ドリル 3
+D:steady hands read signal 27 steady hands read signal 27
+
+G:LANTERN_KEEP
+
+*:DAY_28
+B:KeyQuest - Day 28 - Lantern Keep: Beacon Trial
+T:Day 28 の案内です。
+ :アーク: Lantern Keep. 数字段と実用的な番号入力を練習する灯台.
+ :重点: 数字段と実用的な番号入力を練習する灯台.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)1&2&3&4&5&6&7&8&9&0 - ドリル 1
+D:1234 567 890 1234 567 890 1234 567 890 1234 567 890 1234 567 890
+I:(2)g&a&t&e&1&2&r&o&m&3&4&p - ドリル 2
+D:gate 12 room 34 path 56 gate 12 room 34 path 56
+I:(3)m&a&r&k&7&8&t&h&e&n&o&p - ドリル 3
+D:mark 78 then open 90 mark 78 then open 90 mark 78 then open 90
+I:(4)t&h&e&b&a&c&o&n&p&s&l&v - ドリル 4
+D:the beacon opens at level 28. the beacon opens at level 28.
+
+G:LANTERN_KEEP
+
+*:DAY_29
+B:KeyQuest - Day 29 - Ashen Forge: Left Shift Spark
+T:Day 29 の案内です。
+ :アーク: Ashen Forge. Shift キーと大文字を鍛える灰の鍛冶場.
+ :重点: Shift キーと大文字を鍛える灰の鍛冶場.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)A&S&D&F - ドリル 1
+D:A S D F A S D F A S D F A S D F A S D F A S D F A S D F A S D F
+I:(2)A&a&S&s&D&d&F&f - ドリル 2
+D:A a S s D d F f A a S s D d F f A a S s D d F f A a S s D d F f
+I:(3)A&s&k&D&a&d&F&l&S&f&e - ドリル 3
+D:Ask Dad Fall Safe Ask Dad Fall Safe Ask Dad Fall Safe
+
+G:ASHEN_FORGE
+
+*:DAY_30
+B:KeyQuest - Day 30 - Ashen Forge: Right Shift Spark
+T:Day 30 の案内です。
+ :アーク: Ashen Forge. Shift キーと大文字を鍛える灰の鍛冶場.
+ :重点: Shift キーと大文字を鍛える灰の鍛冶場.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)J&K&L&H - ドリル 1
+D:J K L H J K L H J K L H J K L H J K L H J K L H J K L H J K L H
+I:(2)J&j&K&k&L&l&H&h - ドリル 2
+D:J j K k L l H h J j K k L l H h J j K k L l H h J j K k L l H h
+I:(3)J&o&y&K&e&L&a&k&H&i&l - ドリル 3
+D:Joy Key Lake Hill Joy Key Lake Hill Joy Key Lake Hill
+
+G:ASHEN_FORGE
+
+*:DAY_31
+B:KeyQuest - Day 31 - Ashen Forge: Capital Names
+T:Day 31 の案内です。
+ :アーク: Ashen Forge. Shift キーと大文字を鍛える灰の鍛冶場.
+ :重点: Shift キーと大文字を鍛える灰の鍛冶場.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)A&d&a&K&e&n&L&i&J&o - ドリル 1
+D:Ada Ken Lia Jo Ada Ken Lia Jo Ada Ken Lia Jo Ada Ken Lia Jo
+I:(2)M&i&r&a&N&o&V&l&e&O&w&n - ドリル 2
+D:Mira Nora Vale Owen Mira Nora Vale Owen Mira Nora Vale Owen
+I:(3)A&d&a&n&K&e&r - ドリル 3
+D:Ada and Ken read Ada and Ken read Ada and Ken read Ada and Ken read
+
+G:ASHEN_FORGE
+
+*:DAY_32
+B:KeyQuest - Day 32 - Ashen Forge: Sentence Starts
+T:Day 32 の案内です。
+ :アーク: Ashen Forge. Shift キーと大文字を鍛える灰の鍛冶場.
+ :重点: Shift キーと大文字を鍛える灰の鍛冶場.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)K&e&p&c&a&l&m&.&H&o&d&h - ドリル 1
+D:Keep calm. Hold home. Type true.
+I:(2)T&h&e&f&o&r&g&l&w&s&.&k - ドリル 2
+D:The forge glows. The key cools.
+I:(3)S&t&a&r&e&c&h&l&i&n&w&. - ドリル 3
+D:Start each line with care.
+
+G:ASHEN_FORGE
+
+*:DAY_33
+B:KeyQuest - Day 33 - Ashen Forge: Title Case
+T:Day 33 の案内です。
+ :アーク: Ashen Forge. Shift キーと大文字を鍛える灰の鍛冶場.
+ :重点: Shift キーと大文字を鍛える灰の鍛冶場.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)A&s&h&e&n&F&o&r&g - ドリル 1
+D:Ashen Forge Ashen Forge Ashen Forge Ashen Forge Ashen Forge
+I:(2)S&i&l&v&e&r&K&y&Q&u&t&G - ドリル 2
+D:Silver Key Quiet Gate Silver Key Quiet Gate Silver Key Quiet Gate
+I:(3)T&h&e&B&r&i&g&t&A&n&v&l - ドリル 3
+D:The Bright Anvil Shapes The Silent Key
+
+G:ASHEN_FORGE
+
+*:DAY_34
+B:KeyQuest - Day 34 - Ashen Forge: Shift Review
+T:Day 34 の案内です。
+ :アーク: Ashen Forge. Shift キーと大文字を鍛える灰の鍛冶場.
+ :重点: Shift キーと大文字を鍛える灰の鍛冶場.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)A&j&S&k&D&l&F&h - ドリル 1
+D:A j S k D l F h A j S k D l F h A j S k D l F h A j S k D l F h
+I:(2)C&a&l&m&H&n&d&s&S&h&p&e - ドリル 2
+D:Calm Hands Shape Bright Keys
+I:(3)A&s&t&e&a&d&y&h&n&c&l&i - ドリル 3
+D:A steady hand can lift every letter.
+
+G:ASHEN_FORGE
+
+*:DAY_35
+B:KeyQuest - Day 35 - Ashen Forge: Anvil Trial
+T:Day 35 の案内です。
+ :アーク: Ashen Forge. Shift キーと大文字を鍛える灰の鍛冶場.
+ :重点: Shift キーと大文字を鍛える灰の鍛冶場.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)A&S&D&F&J&K&L&H - ドリル 1
+D:A S D F J K L H A S D F J K L H A S D F J K L H A S D F J K L H
+I:(2)A&d&a&K&e&n&M&i&r&O&w - ドリル 2
+D:Ada Ken Mira Owen Ada Ken Mira Owen Ada Ken Mira Owen
+I:(3)T&h&e&A&s&n&F&o&r&g&a&p - ドリル 3
+D:The Ashen Forge shapes a calm bright key.
+I:(4)H&o&l&d&h&m&e&,&t&a&p&S - ドリル 4
+D:Hold home, tap Shift, and let the anvil ring.
+
+G:ASHEN_FORGE
+
+*:DAY_36
+B:KeyQuest - Day 36 - Windspire: Even Steps
+T:Day 36 の案内です。
+ :アーク: Windspire. 速度の制御とリズムを学ぶ風の塔.
+ :重点: 速度の制御とリズムを学ぶ風の塔.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)t&a&p&r&e&s - ドリル 1
+D:tap rest tap rest tap rest tap rest tap rest tap rest
+I:(2)c&a&l&m&p&e&s&t&d&y - ドリル 2
+D:calm pace steady pace calm pace steady pace calm pace steady pace
+I:(3)E&v&e&r&y&s&m&a&l&t&p&k - ドリル 3
+D:Every small step keeps the wind in time.
+
+G:WINDSPIRE
+
+*:DAY_37
+B:KeyQuest - Day 37 - Windspire: Short Bursts
+T:Day 37 の案内です。
+ :アーク: Windspire. 速度の制御とリズムを学ぶ風の塔.
+ :重点: 速度の制御とリズムを学ぶ風の塔.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)f&a&s&t&o&p&c&l&m&g - ドリル 1
+D:fast stop calm go fast stop calm go fast stop calm go
+I:(2)w&i&n&d&r&u&s&t&h&e - ドリル 2
+D:wind runs then rests wind runs then rests wind runs then rests
+I:(3)B&u&r&s&t&f&o&a&m&e&n&, - ドリル 3
+D:Burst for a moment, then return to calm hands.
+
+G:WINDSPIRE
+
+*:DAY_38
+B:KeyQuest - Day 38 - Windspire: Long Cadence
+T:Day 38 の案内です。
+ :アーク: Windspire. 速度の制御とリズムを学ぶ風の塔.
+ :重点: 速度の制御とリズムを学ぶ風の塔.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)t&h&e&w&i&n&d&c&a&r&s&q - ドリル 1
+D:the wind carries a quiet rhythm over the road
+I:(2)s&t&e&a&d&y&f&i&n&g&r&c - ドリル 2
+D:steady fingers cross the high bridge with care
+I:(3)p&a&c&e&t&h&l&i&n&s&o&v - ドリル 3
+D:pace the line so every word lands cleanly
+
+G:WINDSPIRE
+
+*:DAY_39
+B:KeyQuest - Day 39 - Windspire: Alternate Pace
+T:Day 39 の案内です。
+ :アーク: Windspire. 速度の制御とリズムを学ぶ風の塔.
+ :重点: 速度の制御とリズムを学ぶ風の塔.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)s&l&o&w&q&u&i&c&k - ドリル 1
+D:slow slow quick quick slow slow quick quick slow slow quick quick
+I:(2)c&a&l&m&b&r&i&g&h&t - ドリル 2
+D:calm calm bright bright calm calm bright bright
+I:(3)C&h&a&n&g&e&p&c&o&l&y&w - ドリル 3
+D:Change pace only when the hands stay quiet.
+
+G:WINDSPIRE
+
+*:DAY_40
+B:KeyQuest - Day 40 - Windspire: Breath Marks
+T:Day 40 の案内です。
+ :アーク: Windspire. 速度の制御とリズムを学ぶ風の塔.
+ :重点: 速度の制御とリズムを学ぶ風の塔.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)b&r&e&a&t&h&,&y&p&u&s&. - ドリル 1
+D:breathe, type, pause. breathe, type, pause.
+I:(2)s&h&o&r&t&w&i&n&d&,&l&g - ドリル 2
+D:short wind, long road. calm hands, clean words.
+I:(3)L&e&t&a&c&h&o&m&s&l&w&r - ドリル 3
+D:Let each comma slow the run.
+
+G:WINDSPIRE
+
+*:DAY_41
+B:KeyQuest - Day 41 - Windspire: Gale Review
+T:Day 41 の案内です。
+ :アーク: Windspire. 速度の制御とリズムを学ぶ風の塔.
+ :重点: 速度の制御とリズムを学ぶ風の塔.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)q&w&e&r&a&s&d&f&z&x&c&v - ドリル 1
+D:qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv
+I:(2)u&i&o&p&j&k&l&;&n&m&,&. - ドリル 2
+D:uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,.
+I:(3)s&t&e&a&d&y&p&c&o&v&r&1 - ドリル 3
+D:steady pace over 12 stones and 34 rails
+
+G:WINDSPIRE
+
+*:DAY_42
+B:KeyQuest - Day 42 - Windspire: Gale Trial
+T:Day 42 の案内です。
+ :アーク: Windspire. 速度の制御とリズムを学ぶ風の塔.
+ :重点: 速度の制御とリズムを学ぶ風の塔.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)t&a&p&r&e&s&q&u&i&c&k&l - ドリル 1
+D:tap rest quick calm tap rest quick calm tap rest quick calm
+I:(2)t&h&e&w&i&n&d&r&s&b&u&a - ドリル 2
+D:the wind rises but the hands stay steady
+I:(3)q&u&i&c&k&s&t&e&p&a&r&f - ドリル 3
+D:quick steps are useful only when accuracy holds
+I:(4)r&i&d&e&t&h&g&a&l&w&y&m - ドリル 4
+D:ride the gale with rhythm, not panic.
+
+G:WINDSPIRE
+
+*:DAY_43
+B:KeyQuest - Day 43 - Clockwork Citadel: Parentheses
+T:Day 43 の案内です。
+ :アーク: Clockwork Citadel. 括弧とプログラミング風の対を練習する機械城.
+ :重点: 括弧とプログラミング風の対を練習する機械城.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)(&) - ドリル 1
+D:( ) () ( ) () ( ) () ( ) () ( ) () ( ) () ( ) () ( ) () ( ) ()
+I:(2)(&a&)&k&e&y&m&p - ドリル 2
+D:(a) (key) (map) (a) (key) (map) (a) (key) (map) (a) (key) (map)
+I:(3)o&p&e&n&(&t&h&g&a&)&d&c - ドリル 3
+D:open (the gate) and close (the lock)
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_44
+B:KeyQuest - Day 44 - Clockwork Citadel: Brackets
+T:Day 44 の案内です。
+ :アーク: Clockwork Citadel. 括弧とプログラミング風の対を練習する機械城.
+ :重点: 括弧とプログラミング風の対を練習する機械城.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)[&] - ドリル 1
+D:[ ] [] [ ] [] [ ] [] [ ] [] [ ] [] [ ] [] [ ] [] [ ] [] [ ] []
+I:(2)[&1&]&2&k&e&y - ドリル 2
+D:[1] [2] [key] [1] [2] [key] [1] [2] [key] [1] [2] [key]
+I:(3)m&a&r&k&[&o&]&t&h&e&n&d - ドリル 3
+D:mark [room] then read [signal]
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_45
+B:KeyQuest - Day 45 - Clockwork Citadel: Braces
+T:Day 45 の案内です。
+ :アーク: Clockwork Citadel. 括弧とプログラミング風の対を練習する機械城.
+ :重点: 括弧とプログラミング風の対を練習する機械城.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1){&} - ドリル 1
+D:{ } {} { } {} { } {} { } {} { } {} { } {} { } {} { } {} { } {}
+I:(2){&k&e&y&}&g&a&t&m&p - ドリル 2
+D:{key} {gate} {map} {key} {gate} {map} {key} {gate} {map}
+I:(3)s&t&o&r&e&{&l&i&g&h&}&b - ドリル 3
+D:store {light} before {shadow}
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_46
+B:KeyQuest - Day 46 - Clockwork Citadel: Angle Gates
+T:Day 46 の案内です。
+ :アーク: Clockwork Citadel. 括弧とプログラミング風の対を練習する機械城.
+ :重点: 括弧とプログラミング風の対を練習する機械城.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)<&> - ドリル 1
+D:< > <> < > <> < > <> < > <> < > <> < > <> < > <> < > <> < > <>
+I:(2)<&k&e&y&>&g&a&t&p&h - ドリル 2
+D:<key> <gate> <path> <key> <gate> <path> <key> <gate> <path>
+I:(3)r&e&a&d&<&s&i&g&n&l&>&b - ドリル 3
+D:read <signal> before <system> moves
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_47
+B:KeyQuest - Day 47 - Clockwork Citadel: Nested Pairs
+T:Day 47 の案内です。
+ :アーク: Clockwork Citadel. 括弧とプログラミング風の対を練習する機械城.
+ :重点: 括弧とプログラミング風の対を練習する機械城.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)(&[&]&)&{&} - ドリル 1
+D:([]) ({}) ([]) ({}) ([]) ({}) ([]) ({}) ([]) ({}) ([]) ({})
+I:(2)[&m&a&p&]&(&r&o&)&{&k&e - ドリル 2
+D:[map](room) {key} [map](room) {key} [map](room) {key}
+I:(3)o&p&e&n&(&[&q&u&i&t&]&) - ドリル 3
+D:open ([quiet]) gears with {steady} hands
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_48
+B:KeyQuest - Day 48 - Clockwork Citadel: Gear Review
+T:Day 48 の案内です。
+ :アーク: Clockwork Citadel. 括弧とプログラミング風の対を練習する機械城.
+ :重点: 括弧とプログラミング風の対を練習する機械城.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)(&)&[&]&{&}&<&> - ドリル 1
+D:() [] {} <> () [] {} <> () [] {} <> () [] {} <> () [] {} <>
+I:(2)g&e&a&r&[&1&]&t&u&n&s&( - ドリル 2
+D:gear[1] turns (slow) while {hands} return
+I:(3)c&l&o&k&w&r&e&y&s&n&d&p - ドリル 3
+D:clockwork keys need paired symbols in order
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_49
+B:KeyQuest - Day 49 - Clockwork Citadel: Gearheart Trial
+T:Day 49 の案内です。
+ :アーク: Clockwork Citadel. 括弧とプログラミング風の対を練習する機械城.
+ :重点: 括弧とプログラミング風の対を練習する機械城.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)(&)&[&]&{&}&<&> - ドリル 1
+D:() [] {} <> () [] {} <> () [] {} <> () [] {} <> () [] {} <>
+I:(2)o&p&e&n&(&g&a&r&)&t&h&c - ドリル 2
+D:open (gear) then close [vault] with {care}
+I:(3)t&h&e&<&g&a&r&>&c&p&s&l - ドリル 3
+D:the <gearheart> accepts clean paired keys
+I:(4)m&a&t&c&h&e&v&r&y&b&k&f - ドリル 4
+D:match every bracket before the engine wakes.
+
+G:CLOCKWORK_CITADEL
+
+*:DAY_50
+B:KeyQuest - Day 50 - Starfall Library: Math Signs
+T:Day 50 の案内です。
+ :アーク: Starfall Library. 記号、演算子、コード風の流れを読む星降る図書館.
+ :重点: 記号、演算子、コード風の流れを読む星降る図書館.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)1&+&2&=&3 - ドリル 1
+D:1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3
+I:(2)4&-&1&=&3 - ドリル 2
+D:4 - 1 = 3 4 - 1 = 3 4 - 1 = 3 4 - 1 = 3 4 - 1 = 3 4 - 1 = 3
+I:(3)l&i&g&h&t&+&f&o&c&u&s&= - ドリル 3
+D:light + focus = clear typing
+
+G:STARFALL_LIBRARY
+
+*:DAY_51
+B:KeyQuest - Day 51 - Starfall Library: Slash And Star
+T:Day 51 の案内です。
+ :アーク: Starfall Library. 記号、演算子、コード風の流れを読む星降る図書館.
+ :重点: 記号、演算子、コード風の流れを読む星降る図書館.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)/&* - ドリル 1
+D:/ * / * / * / * / * / * / * / * / * / * / * / * / * / * / * / *
+I:(2)p&a&t&h&/&m&s&r&*&k&e&y - ドリル 2
+D:path / map star * key path / map star * key path / map star * key
+I:(3)r&e&a&d&/&s&l&o&w&y&n&m - ドリル 3
+D:read / slowly and mark * carefully
+
+G:STARFALL_LIBRARY
+
+*:DAY_52
+B:KeyQuest - Day 52 - Starfall Library: Quotes
+T:Day 52 の案内です。
+ :アーク: Starfall Library. 記号、演算子、コード風の流れを読む星降る図書館.
+ :重点: 記号、演算子、コード風の流れを読む星降る図書館.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)"&k&e&y&m&a&p - ドリル 1
+D:"key" "map" "key" "map" "key" "map" "key" "map" "key" "map"
+I:(2)'&g&o&r&e&s&t - ドリル 2
+D:'go' 'rest' 'go' 'rest' 'go' 'rest' 'go' 'rest' 'go' 'rest'
+I:(3)t&h&e&s&i&g&n&a&y&"&o&l - ドリル 3
+D:the sign says "hold steady" before moving
+
+G:STARFALL_LIBRARY
+
+*:DAY_53
+B:KeyQuest - Day 53 - Starfall Library: Colon Signals
+T:Day 53 の案内です。
+ :アーク: Starfall Library. 記号、演算子、コード風の流れを読む星降る図書館.
+ :重点: 記号、演算子、コード風の流れを読む星降る図書館.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)k&e&y&:&g&a&t&;&m&p&h - ドリル 1
+D:key: gate; map: path; key: gate; map: path; key: gate; map: path;
+I:(2)n&o&t&e&:&b&r&a&h&;&y&p - ドリル 2
+D:note: breathe; type: slowly; check: accuracy;
+I:(3)s&i&g&n&a&l&:&c&e&r&;&h - ドリル 3
+D:signal: clear; hands: calm; route: open;
+
+G:STARFALL_LIBRARY
+
+*:DAY_54
+B:KeyQuest - Day 54 - Starfall Library: Code Words
+T:Day 54 の案内です。
+ :アーク: Starfall Library. 記号、演算子、コード風の流れを読む星降る図書館.
+ :重点: 記号、演算子、コード風の流れを読む星降る図書館.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)i&f&g&a&t&e&=&o&p&n&h&y - ドリル 1
+D:if gate = open then type calm words
+I:(2)c&o&u&n&t&+&f&s&-&p&a&i - ドリル 2
+D:count + focus - panic = steady hands
+I:(3)p&a&t&h&/&r&o&m&k&e&y&s - ドリル 3
+D:path / room / key keeps the record clear
+
+G:STARFALL_LIBRARY
+
+*:DAY_55
+B:KeyQuest - Day 55 - Starfall Library: Archive Review
+T:Day 55 の案内です。
+ :アーク: Starfall Library. 記号、演算子、コード風の流れを読む星降る図書館.
+ :重点: 記号、演算子、コード風の流れを読む星降る図書館.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)1&+&2&=&3&;&4&- - ドリル 1
+D:1 + 2 = 3; 4 - 1 = 3; 1 + 2 = 3; 4 - 1 = 3; 1 + 2 = 3; 4 - 1 = 3;
+I:(2)r&e&c&o&d&:&"&s&t&a&y&; - ドリル 2
+D:record: "steady"; status: "clear";
+I:(3)t&h&e&a&r&c&i&v&o&p&n&s - ドリル 3
+D:the archive opens when symbols stay in order
+
+G:STARFALL_LIBRARY
+
+*:DAY_56
+B:KeyQuest - Day 56 - Starfall Library: Archivist Trial
+T:Day 56 の案内です。
+ :アーク: Starfall Library. 記号、演算子、コード風の流れを読む星降る図書館.
+ :重点: 記号、演算子、コード風の流れを読む星降る図書館.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)k&e&y&+&m&a&p&=&t&h&;&c - ドリル 1
+D:key + map = path; path + calm = progress;
+I:(2)r&e&a&d&"&s&i&g&n&l&/&m - ドリル 2
+D:read "signal" / mark "gate" / hold focus
+I:(3)i&f&r&o&m&=&c&l&e&a&t&h - ドリル 3
+D:if room = clear then move slowly.
+I:(4)t&h&e&a&r&c&i&v&s&u&y&m - ドリル 4
+D:the archivist trusts accurate symbols.
+
+G:STARFALL_LIBRARY
+
+*:DAY_57
+B:KeyQuest - Day 57 - Dragon Spine: Pressure Warmup
+T:Day 57 の案内です。
+ :アーク: Dragon Spine. 圧力の中で正確さを守る竜の尾根.
+ :重点: 圧力の中で正確さを守る竜の尾根.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)h&o&l&d&c&a&m&t&y&p&e&r - ドリル 1
+D:hold calm type true hold calm type true hold calm type true
+I:(2)t&h&e&r&i&d&g&s&b&u&a&n - ドリル 2
+D:the ridge is high but the hands stay low
+I:(3)a&c&u&r&y&i&s&t&h&e&l&d - ドリル 3
+D:accuracy is the shield before speed.
+
+G:DRAGON_SPINE
+
+*:DAY_58
+B:KeyQuest - Day 58 - Dragon Spine: Longer Climb
+T:Day 58 の案内です。
+ :アーク: Dragon Spine. 圧力の中で正確さを守る竜の尾根.
+ :重点: 圧力の中で正確さを守る竜の尾根.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)t&h&e&d&r&a&g&o&n&i&s&b - ドリル 1
+D:the dragon road rises beyond the quiet stone gate
+I:(2)e&a&c&h&r&f&u&l&w&o&d&k - ドリル 2
+D:each careful word keeps the traveler on the ridge
+I:(3)f&i&n&s&h&t&e&l&a&c&y&b - ドリル 3
+D:finish the line as cleanly as it began
+
+G:DRAGON_SPINE
+
+*:DAY_59
+B:KeyQuest - Day 59 - Dragon Spine: Heat Control
+T:Day 59 の案内です。
+ :アーク: Dragon Spine. 圧力の中で正確さを守る竜の尾根.
+ :重点: 圧力の中で正確さを守る竜の尾根.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)G&a&t&e&1&2&o&p&n&s&f&r - ドリル 1
+D:Gate 12 opens after Signal 34.
+I:(2)D&r&a&g&o&n&7&c&i&l&e&s - ドリル 2
+D:Dragon 7 circles Tower 9 before dawn.
+I:(3)K&e&p&3&c&a&l&m&b&r&t&h - ドリル 3
+D:Keep 3 calm breaths before Route 5.
+
+G:DRAGON_SPINE
+
+*:DAY_60
+B:KeyQuest - Day 60 - Dragon Spine: No Panic
+T:Day 60 の案内です。
+ :アーク: Dragon Spine. 圧力の中で正確さを守る竜の尾根.
+ :重点: 圧力の中で正確さを守る竜の尾根.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)b&r&e&a&t&h&,&c&o&n&i&u - ドリル 1
+D:breathe, correct, continue; do not chase the error.
+I:(2)t&h&e&o&p&a&b&n&d&s&,&u - ドリル 2
+D:the hot path bends, but steady fingers recover.
+I:(3)s&l&o&w&c&r&e&t&i&n&b&a - ドリル 3
+D:slow correction beats fast panic every time.
+
+G:DRAGON_SPINE
+
+*:DAY_61
+B:KeyQuest - Day 61 - Dragon Spine: Focus Run
+T:Day 61 の案内です。
+ :アーク: Dragon Spine. 圧力の中で正確さを守る竜の尾根.
+ :重点: 圧力の中で正確さを守る竜の尾根.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)T&h&e&b&r&i&g&t&d&n&a&o - ドリル 1
+D:The bright ridge narrows as the old dragon wakes.
+I:(2)A&c&a&l&m&t&r&v&e&d&s&h - ドリル 2
+D:A calm traveler reads the wind and keeps moving.
+I:(3)E&v&e&r&y&c&l&a&n&w&o&d - ドリル 3
+D:Every clean word becomes another safe step.
+
+G:DRAGON_SPINE
+
+*:DAY_62
+B:KeyQuest - Day 62 - Dragon Spine: Wyrm Review
+T:Day 62 の案内です。
+ :アーク: Dragon Spine. 圧力の中で正確さを守る竜の尾根.
+ :重点: 圧力の中で正確さを守る竜の尾根.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)R&o&u&t&e&4&2&:&c&l&i&m - ドリル 1
+D:Route 42: climb, pause, breathe, continue.
+I:(2)T&h&e&r&i&d&g&m&a&k&s&y - ドリル 2
+D:The ridge marker says "steady hands survive."
+I:(3)f&o&c&u&s&+&p&a&t&i&e&n - ドリル 3
+D:focus + patience = safe travel under pressure
+
+G:DRAGON_SPINE
+
+*:DAY_63
+B:KeyQuest - Day 63 - Dragon Spine: Wyrm Trial
+T:Day 63 の案内です。
+ :アーク: Dragon Spine. 圧力の中で正確さを守る竜の尾根.
+ :重点: 圧力の中で正確さを守る竜の尾根.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)T&h&e&d&r&a&g&o&n&w&t&c - ドリル 1
+D:The dragon watches each key and every pause.
+I:(2)R&o&u&t&e&6&3&i&s&n&a&r - ドリル 2
+D:Route 63 is narrow, bright, and unforgiving.
+I:(3)B&r&e&a&t&h&,&y&p&c&o&v - ドリル 3
+D:Breathe, type, recover; the ridge will not hurry.
+I:(4)T&h&e&w&y&r&m&i&l&d&s&t - ドリル 4
+D:The wyrm yields to calm accurate hands.
+
+G:DRAGON_SPINE
+
+*:DAY_64
+B:KeyQuest - Day 64 - Moonlit Labyrinth: Slow Repair
+T:Day 64 の案内です。
+ :アーク: Moonlit Labyrinth. 苦手キーを落ち着いて修復する月明かりの迷宮.
+ :重点: 苦手キーを落ち着いて修復する月明かりの迷宮.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)q&z&p&; - ドリル 1
+D:q z p ; q z p ; q z p ; q z p ; q z p ; q z p ; q z p ; q z p ;
+I:(2)v&b&n&m - ドリル 2
+D:v b n m v b n m v b n m v b n m v b n m v b n m v b n m v b n m
+I:(3)s&l&o&w&r&e&p&a&i&m&k&t - ドリル 3
+D:slow repair makes the lost path visible
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_65
+B:KeyQuest - Day 65 - Moonlit Labyrinth: Outer Keys
+T:Day 65 の案内です。
+ :アーク: Moonlit Labyrinth. 苦手キーを落ち着いて修復する月明かりの迷宮.
+ :重点: 苦手キーを落ち着いて修復する月明かりの迷宮.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)q&a&;&p - ドリル 1
+D:qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p qa ;p
+I:(2)z&q&p&; - ドリル 2
+D:zq p; zq p; zq p; zq p; zq p; zq p; zq p; zq p; zq p; zq p;
+I:(3)q&u&i&e&t&p&a&h&s&b&y&o - ドリル 3
+D:quiet paths pass beyond pale pillars
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_66
+B:KeyQuest - Day 66 - Moonlit Labyrinth: Bottom Repair
+T:Day 66 の案内です。
+ :アーク: Moonlit Labyrinth. 苦手キーを落ち着いて修復する月明かりの迷宮.
+ :重点: 苦手キーを落ち着いて修復する月明かりの迷宮.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)c&v&n&m&b - ドリル 1
+D:cv nm vb cv nm vb cv nm vb cv nm vb cv nm vb cv nm vb cv nm vb
+I:(2)m&o&v&e&b&r&a&n&c&l - ドリル 2
+D:move brave never calm move brave never calm move brave never calm
+I:(3)t&h&e&m&a&z&b&n&d&s&l&o - ドリル 3
+D:the maze bends below the home row
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_67
+B:KeyQuest - Day 67 - Moonlit Labyrinth: Symbol Repair
+T:Day 67 の案内です。
+ :アーク: Moonlit Labyrinth. 苦手キーを落ち着いて修復する月明かりの迷宮.
+ :重点: 苦手キーを落ち着いて修復する月明かりの迷宮.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)(&)&[&]&{&} - ドリル 1
+D:() [] {} () [] {} () [] {} () [] {} () [] {} () [] {} () [] {}
+I:(2)1&+&2&=&3 - ドリル 2
+D:1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3 1 + 2 = 3
+I:(3)r&e&p&a&i&[&s&m&l&]&o&b - ドリル 3
+D:repair [small] errors before {large} ones
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_68
+B:KeyQuest - Day 68 - Moonlit Labyrinth: Mirror Paths
+T:Day 68 の案内です。
+ :アーク: Moonlit Labyrinth. 苦手キーを落ち着いて修復する月明かりの迷宮.
+ :重点: 苦手キーを落ち着いて修復する月明かりの迷宮.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)a&s&d&f&j&k&l&; - ドリル 1
+D:asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj asdf fdsa jkl; ;lkj
+I:(2)q&w&e&r&u&i&o&p - ドリル 2
+D:qwer rewq uiop poiu qwer rewq uiop poiu qwer rewq uiop poiu
+I:(3)l&e&f&t&p&a&h&r&i&g&b&o - ドリル 3
+D:left path right path both return home
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_69
+B:KeyQuest - Day 69 - Moonlit Labyrinth: Labyrinth Review
+T:Day 69 の案内です。
+ :アーク: Moonlit Labyrinth. 苦手キーを落ち着いて修復する月明かりの迷宮.
+ :重点: 苦手キーを落ち着いて修復する月明かりの迷宮.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)q&u&i&e&t&z&b&r&a&p&h&s - ドリル 1
+D:quiet zebra paths puzzle every brave novice
+I:(2)s&y&m&b&o&l&,&n&u&e&r&a - ドリル 2
+D:symbols, numbers, and outer keys need patience.
+I:(3)c&o&r&e&t&h&s&m&a&l&i&b - ドリル 3
+D:correct the small miss before moving onward
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_70
+B:KeyQuest - Day 70 - Moonlit Labyrinth: Minotaur Trial
+T:Day 70 の案内です。
+ :アーク: Moonlit Labyrinth. 苦手キーを落ち着いて修復する月明かりの迷宮.
+ :重点: 苦手キーを落ち着いて修復する月明かりの迷宮.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)q&z&p&;&v&b&n&m - ドリル 1
+D:q z p ; v b n m q z p ; v b n m q z p ; v b n m q z p ; v b n m
+I:(2)q&u&i&e&t&s&y&m&b&o&l&[ - ドリル 2
+D:quiet symbols [return] after {careful} repair
+I:(3)t&h&e&m&a&z&r&w&d&s&p&i - ドリル 3
+D:the maze rewards patience, not panic.
+I:(4)r&e&c&o&v&a&h&k&y&n&d&l - ドリル 4
+D:recover each key and leave the labyrinth.
+
+G:MOONLIT_LABYRINTH
+
+*:DAY_71
+B:KeyQuest - Day 71 - Obsidian Throne: Mixed Marks
+T:Day 71 の案内です。
+ :アーク: Obsidian Throne. 混合句読点と長文集中を鍛える黒曜の玉座.
+ :重点: 混合句読点と長文集中を鍛える黒曜の玉座.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)w&a&i&t&,&l&o&k&;&y&p&e - ドリル 1
+D:wait, look; type: slowly.
+I:(2)k&e&y&:&f&o&u&n&d&,&g&a - ドリル 2
+D:key: found, gate: open, path: clear.
+I:(3)t&h&e&r&o&n&i&s&d&a&k&; - ドリル 3
+D:the throne is dark; the signal is bright.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_72
+B:KeyQuest - Day 72 - Obsidian Throne: Quote Orders
+T:Day 72 の案内です。
+ :アーク: Obsidian Throne. 混合句読点と長文集中を鍛える黒曜の玉座.
+ :重点: 混合句読点と長文集中を鍛える黒曜の玉座.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)T&h&e&g&u&a&r&d&s&y&,&" - ドリル 1
+D:The guard says, "hold the line."
+I:(2)T&h&e&m&a&p&r&d&s&,&"&t - ドリル 2
+D:The map reads, "turn left, then pause."
+I:(3)S&h&e&w&i&s&p&r&,&"&a&c - ドリル 3
+D:She whispers, "accuracy breaks the seal."
+
+G:OBSIDIAN_THRONE
+
+*:DAY_73
+B:KeyQuest - Day 73 - Obsidian Throne: Long Focus
+T:Day 73 の案内です。
+ :アーク: Obsidian Throne. 混合句読点と長文集中を鍛える黒曜の玉座.
+ :重点: 混合句読点と長文集中を鍛える黒曜の玉座.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)B&e&y&o&n&d&t&h&b&l&a&c - ドリル 1
+D:Beyond the black hall, every comma becomes a breath.
+I:(2)T&h&e&o&l&d&c&r&w&n&a&i - ドリル 2
+D:The old crown waits; calm hands answer without fear.
+I:(3)A&l&o&n&g&i&e&s&y&v&r&a - ドリル 3
+D:A long line is only several small clean choices.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_74
+B:KeyQuest - Day 74 - Obsidian Throne: Clause Chains
+T:Day 74 の案内です。
+ :アーク: Obsidian Throne. 混合句読点と長文集中を鍛える黒曜の玉座.
+ :重点: 混合句読点と長文集中を鍛える黒曜の玉座.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)l&o&k&a&h&e&d&;&b&r&t&n - ドリル 1
+D:look ahead; breathe once; type the next word.
+I:(2)t&h&e&a&l&n&r&o&w&s&;&c - ドリル 2
+D:the hall narrows; the torch dims; focus remains.
+I:(3)s&l&o&w&h&a&n&d&i&;&r&u - ドリル 3
+D:slow hands win; rushed hands repeat the lesson.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_75
+B:KeyQuest - Day 75 - Obsidian Throne: Dense Review
+T:Day 75 の案内です。
+ :アーク: Obsidian Throne. 混合句読点と長文集中を鍛える黒曜の玉座.
+ :重点: 混合句読点と長文集中を鍛える黒曜の玉座.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)R&o&m&7&5&:&"&s&t&e&a&d - ドリル 1
+D:Room 75: "steady," says the silent crown.
+I:(2)G&a&t&e&3&o&p&n&s&;&4&w - ドリル 2
+D:Gate 3 opens; Gate 4 waits; Gate 5 listens.
+I:(3)c&l&e&a&r&m&k&s&,&n&w&o - ドリル 3
+D:clear marks, clean words, and calm recovery.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_76
+B:KeyQuest - Day 76 - Obsidian Throne: Crown Approach
+T:Day 76 の案内です。
+ :アーク: Obsidian Throne. 混合句読点と長文集中を鍛える黒曜の玉座.
+ :重点: 混合句読点と長文集中を鍛える黒曜の玉座.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)T&h&e&o&b&s&i&d&a&n&t&p - ドリル 1
+D:The obsidian steps rise slowly toward the throne.
+I:(2)E&a&c&h&m&r&k&t&e&s&:&o - ドリル 2
+D:Each mark matters: comma, period, colon, quote.
+I:(3)D&o&n&t&r&u&s&h&e&f&i&a - ドリル 3
+D:Do not rush the final line before the crown.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_77
+B:KeyQuest - Day 77 - Obsidian Throne: Crown Trial
+T:Day 77 の案内です。
+ :アーク: Obsidian Throne. 混合句読点と長文集中を鍛える黒曜の玉座.
+ :重点: 混合句読点と長文集中を鍛える黒曜の玉座.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)T&h&e&c&r&o&w&n&s&a&y&, - ドリル 1
+D:The crown says, "type clearly, then continue."
+I:(2)R&o&m&7&:&p&a&u&s&e&,&b - ドリル 2
+D:Room 77: pause, breathe, correct, proceed.
+I:(3)L&o&n&g&f&c&u&s&t&r&d&a - ドリル 3
+D:Long focus turns dark punctuation into light.
+I:(4)T&h&e&t&r&o&n&p&s&f&a&d - ドリル 4
+D:The throne opens for steady accurate hands.
+
+G:OBSIDIAN_THRONE
+
+*:DAY_78
+B:KeyQuest - Day 78 - Dawn Citadel: Full Keyboard Scan
+T:Day 78 の案内です。
+ :アーク: Dawn Citadel. 全キーボードの総復習を行う夜明けの城塞.
+ :重点: 全キーボードの総復習を行う夜明けの城塞.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)q&w&e&r&a&s&d&f&z&x&c&v - ドリル 1
+D:qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv qwer asdf zxcv
+I:(2)u&i&o&p&j&k&l&;&n&m&,&. - ドリル 2
+D:uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,. uiop jkl; nm,.
+I:(3)1&2&3&4&5&6&7&8&9&0 - ドリル 3
+D:1234 567 890 1234 567 890 1234 567 890 1234 567 890 1234 567 890
+
+G:DAWN_CITADEL
+
+*:DAY_79
+B:KeyQuest - Day 79 - Dawn Citadel: Capital Review
+T:Day 79 の案内です。
+ :アーク: Dawn Citadel. 全キーボードの総復習を行う夜明けの城塞.
+ :重点: 全キーボードの総復習を行う夜明けの城塞.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)D&a&w&n&C&i&t&d&e&l&o&p - ドリル 1
+D:Dawn Citadel opens Gate 79 with calm hands.
+I:(2)M&i&r&a&n&d&O&w&e&c&y&K - ドリル 2
+D:Mira and Owen carry Key 12 to Tower 34.
+I:(3)E&v&e&r&y&C&a&p&i&t&l&L - ドリル 3
+D:Every Capital Letter returns to home.
+
+G:DAWN_CITADEL
+
+*:DAY_80
+B:KeyQuest - Day 80 - Dawn Citadel: Symbol Review
+T:Day 80 の案内です。
+ :アーク: Dawn Citadel. 全キーボードの総復習を行う夜明けの城塞.
+ :重点: 全キーボードの総復習を行う夜明けの城塞.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)(&)&[&]&{&}&<&> - ドリル 1
+D:() [] {} <> () [] {} <> () [] {} <> () [] {} <> () [] {} <>
+I:(2)1&+&2&=&3&; - ドリル 2
+D:1 + 2 = 3; 1 + 2 = 3; 1 + 2 = 3; 1 + 2 = 3; 1 + 2 = 3; 1 + 2 = 3;
+I:(3)r&e&c&o&d&[&a&w&n&]&=&{ - ドリル 3
+D:record [dawn] = {clear} + "focus"
+
+G:DAWN_CITADEL
+
+*:DAY_81
+B:KeyQuest - Day 81 - Dawn Citadel: Phrase Review
+T:Day 81 の案内です。
+ :アーク: Dawn Citadel. 全キーボードの総復習を行う夜明けの城塞.
+ :重点: 全キーボードの総復習を行う夜明けの城塞.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)t&h&e&d&a&w&n&c&i&l&g&r - ドリル 1
+D:the dawn citadel gathers every lesson into one path
+I:(2)s&t&e&a&d&y&r&h&m&c&i&l - ドリル 2
+D:steady rhythm carries letters, numbers, and marks
+I:(3)f&u&l&m&a&s&t&e&r&y&b&g - ドリル 3
+D:full mastery begins with one clean line at a time
+
+G:DAWN_CITADEL
+
+*:DAY_82
+B:KeyQuest - Day 82 - Dawn Citadel: Recovery Review
+T:Day 82 の案内です。
+ :アーク: Dawn Citadel. 全キーボードの総復習を行う夜明けの城塞.
+ :重点: 全キーボードの総復習を行う夜明けの城塞.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)q&z&p&;&v&b&n&m - ドリル 1
+D:q z p ; v b n m q z p ; v b n m q z p ; v b n m q z p ; v b n m
+I:(2)r&e&c&o&v&[&q&u&i&t&l&y - ドリル 2
+D:recover [quietly] after {difficult} symbols
+I:(3)t&h&e&c&i&a&d&l&r&w&s&m - ドリル 3
+D:the citadel rewards calm correction
+
+G:DAWN_CITADEL
+
+*:DAY_83
+B:KeyQuest - Day 83 - Dawn Citadel: Final Review
+T:Day 83 の案内です。
+ :アーク: Dawn Citadel. 全キーボードの総復習を行う夜明けの城塞.
+ :重点: 全キーボードの総復習を行う夜明けの城塞.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)G&a&t&e&8&3&o&p&n&s&w&h - ドリル 1
+D:Gate 83 opens when "focus" stays bright.
+I:(2)D&a&w&n&l&i&g&h&t&c&r&o - ドリル 2
+D:Dawn light crosses room 12, hall 34, and tower 56.
+I:(3)t&y&p&e&s&l&o&w&n&u&g&h - ドリル 3
+D:type slowly enough to finish cleanly
+
+G:DAWN_CITADEL
+
+*:DAY_84
+B:KeyQuest - Day 84 - Dawn Citadel: Dawn Trial
+T:Day 84 の案内です。
+ :アーク: Dawn Citadel. 全キーボードの総復習を行う夜明けの城塞.
+ :重点: 全キーボードの総復習を行う夜明けの城塞.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)q&w&e&r&a&s&d&f&z&x&c&v - ドリル 1
+D:qwer asdf zxcv uiop qwer asdf zxcv uiop qwer asdf zxcv uiop
+I:(2)D&a&w&n&C&i&t&d&e&l&:&[ - ドリル 2
+D:Dawn Citadel: [ready] = {calm} + "accuracy"
+I:(3)E&v&e&r&y&o&w&,&n&u&m&b - ドリル 3
+D:Every row, number, and mark returns home.
+I:(4)T&h&e&f&i&n&a&l&g&t&p&r - ドリル 4
+D:The final gate appears in the morning light.
+
+G:DAWN_CITADEL
+
+*:DAY_85
+B:KeyQuest - Day 85 - Final Gate: First Seal
+T:Day 85 の案内です。
+ :アーク: Final Gate. 最後の統合タイピングクエスト.
+ :重点: 最後の統合タイピングクエスト.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)a&s&d&f&q&w&e&r&z&x&c&v - ドリル 1
+D:asdf qwer zxcv 1234 asdf qwer zxcv 1234 asdf qwer zxcv 1234
+I:(2)T&h&e&f&i&r&s&t&a&l&o&p - ドリル 2
+D:The first seal opens for calm accurate hands.
+I:(3)R&e&v&i&w&r&y&o&b&f&t&h - ドリル 3
+D:Review every row before the final spell begins.
+I:(4)s&t&e&a&d&y&f&o&c&u&r&i - ドリル 4
+D:steady focus carries the key toward silence
+
+G:FINAL_GATE
+
+*:DAY_86
+B:KeyQuest - Day 86 - Final Gate: Second Seal
+T:Day 86 の案内です。
+ :アーク: Final Gate. 最後の統合タイピングクエスト.
+ :重点: 最後の統合タイピングクエスト.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)S&e&a&l&2&:&"&H&o&d&f&c - ドリル 1
+D:Seal 2: "Hold focus," says the old gate.
+I:(2)K&e&y&8&6&t&u&r&n&s&l&o - ドリル 2
+D:Key 86 turns slowly; the path remains clear.
+I:(3)A&B&r&i&g&h&t&H&a&n&d&y - ドリル 3
+D:A Bright Hand types 3 clean lines before dawn.
+I:(4)n&u&m&b&e&r&s&a&d&k&o&y - ドリル 4
+D:numbers and marks obey patient fingers
+
+G:FINAL_GATE
+
+*:DAY_87
+B:KeyQuest - Day 87 - Final Gate: Third Seal
+T:Day 87 の案内です。
+ :アーク: Final Gate. 最後の統合タイピングクエスト.
+ :重点: 最後の統合タイピングクエスト.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)i&f&g&a&t&e&=&o&p&n&h&l - ドリル 1
+D:if gate = open then hold steady focus
+I:(2)f&i&n&a&l&[&s&e&]&=&{&c - ドリル 2
+D:final[seal] = {calm} + "accuracy"
+I:(3)p&a&t&h&/&k&e&y&l&i&g&d - ドリル 3
+D:path / key / light leads beyond silence
+I:(4)p&a&i&r&e&d&s&y&m&b&o&l - ドリル 4
+D:paired symbols guard the third seal
+
+G:FINAL_GATE
+
+*:DAY_88
+B:KeyQuest - Day 88 - Final Gate: Fourth Seal
+T:Day 88 の案内です。
+ :アーク: Final Gate. 最後の統合タイピングクエスト.
+ :重点: 最後の統合タイピングクエスト.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)T&h&e&L&o&r&d&f&S&i&l&n - ドリル 1
+D:The Lord of Silence waits beyond the final gate.
+I:(2)E&v&e&r&y&l&s&o&n&t&u&a - ドリル 2
+D:Every lesson returns as one quiet line of light.
+I:(3)D&o&n&t&r&u&s&h&e&d&i&g - ドリル 3
+D:Do not rush the ending; complete it cleanly.
+I:(4)a&c&u&r&y&t&n&s&h&e&l&d - ドリル 4
+D:accuracy turns the last shadow into dawn
+
+G:FINAL_GATE
+
+*:DAY_89
+B:KeyQuest - Day 89 - Final Gate: Last Camp
+T:Day 89 の案内です。
+ :アーク: Final Gate. 最後の統合タイピングクエスト.
+ :重点: 最後の統合タイピングクエスト.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)N&o&v&i&c&e&h&a&n&d&s&b - ドリル 1
+D:Novice hands became steady hands over many days.
+I:(2)R&o&w&s&,&n&u&m&b&e&r&y - ドリル 2
+D:Rows, numbers, symbols, and stories gather here.
+I:(3)B&r&e&a&t&h&o&n&c&b&f&i - ドリル 3
+D:Breathe once before the final spell is typed.
+I:(4)t&h&e&l&a&s&c&m&p&i&q&u - ドリル 4
+D:the last camp is quiet, bright, and ready
+
+G:FINAL_GATE
+
+*:DAY_90
+B:KeyQuest - Day 90 - Final Gate: Last Spell Trial
+T:Day 90 の案内です。
+ :アーク: Final Gate. 最後の統合タイピングクエスト.
+ :重点: 最後の統合タイピングクエスト.
+ :正確さを最優先にしましょう。速さは、行をきれいに打ててから自然についてきます。
+I:(1)T&h&e&f&i&n&a&l&g&t&o&p - ドリル 1
+D:The final gate opens when every key returns home.
+I:(2)K&e&y&Q&u&s&t&D&a&9&0&: - ドリル 2
+D:KeyQuest Day 90: "Accuracy breaks the silence."
+I:(3)i&f&o&c&u&s&=&t&e&a&d&y - ドリル 3
+D:if focus = steady then the last spell shines
+I:(4)T&h&e&L&o&r&d&f&S&i&l&n - ドリル 4
+D:The Lord of Silence falls to calm typing.
+
+G:FINAL_GATE
+
+*:ABOUT
+B:KeyQuest タイピングの旅について
+T:この GNU Typist スクリプトは、KeyQuest を90日間のタイピングの旅として多言語化したものです。
+ :D: の打ち込み文は英語のまま全言語で共通です。
+ :メニュー、見出し、説明文だけを日本語にしています。
+ :1日ずつ進め、正確さが崩れたら同じ日を繰り返してください。
+G:MENU
+*:EXIT
+B:KeyQuest での訓練、おつかれさまでした。
+T:毎日少しずつ練習しましょう。正確さが最後の門を開きます。
+X:


### PR DESCRIPTION
## Summary
- Add Japanese, Spanish, French, and German narration variants for the 90-day KeyQuest gtypist journey.
- Keep `D:` typing drills identical across all localized files.
- Document localized usage in README and the curriculum manual.

## Test plan
- Validated label references, `G:` targets, menu targets, and Day 1-90 coverage for all KeyQuest `.typ` files.
- Verified all localized files have the same 300 `D:` drill blocks as `keyquest.typ`.
- Ran linter diagnostics for README, curriculum docs, and all KeyQuest `.typ` files.
- Smoke-checked `ABOUT` and `DAY_90` startup for each localized file with `gtypist` and a timeout.

Closes #6.

Made with [Cursor](https://cursor.com)