### PR TITLE
Document KeyQuest and GNU Typist context

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ This repository contains two terminal lesson scripts:
 
 ## Requirements
 
-Install GNU Typist before running these scripts.
+Install [GNU Typist](https://www.gnu.org/software/gtypist/) before running these scripts. If the web page is unavailable from your network, the same tool documentation is usually available locally after installation:
+
+```sh
+info gtypist
+man gtypist
+```
 
 ### Debian / Ubuntu
 
@@ -71,6 +76,12 @@ gtypist keyquest.typ
 - Localized files translate menus, banners, and guidance only; every `D:` typing line stays identical across languages.
 
 The original KeyQuest game presents lessons through RPG progression, story scenes, scoring, and rewards. GNU Typist is a simpler terminal trainer, so this port keeps the typing substance and reshapes the experience into menus, concise training notes, and drill lines.
+
+## About KeyQuest
+
+[KeyQuest](https://github.com/hideyukiMORI/keyquest) is a terminal typing adventure game for fun and effective practice. The full game adds RPG-style journey progress, saved practice history, weak-key review, rewards, achievements, titles, resources, and language options around the same accuracy-first training philosophy.
+
+This repository is the lightweight GNU Typist companion: it keeps the KeyQuest curriculum, arc structure, and English typing prompts, then packages them as plain `.typ` scripts that can be run directly with gtypist.
 
 ## Recommended Practice
 

--- a/docs/keyquest-curriculum.md
+++ b/docs/keyquest-curriculum.md
@@ -6,6 +6,13 @@ Days 1-28 preserve implemented KeyQuest lesson prompts where they fit GNU Typist
 
 ## How to Run
 
+Install [GNU Typist](https://www.gnu.org/software/gtypist/) first. If that page is unreachable, check the local manual after installing gtypist:
+
+```sh
+info gtypist
+man gtypist
+```
+
 ```sh
 gtypist keyquest.typ
 ```
@@ -198,6 +205,12 @@ A 6-day final integrated quest ending with the Last Spell Trial.
 - Days 1-28 preserve the implemented KeyQuest lesson prompts where they fit GNU Typist.
 - Days 29-90 follow the quest map arc themes from KeyQuest and are authored directly for gtypist.
 - The naming follows the implemented KeyQuest quest map when it differs from older planning documents.
+
+## Relationship To KeyQuest
+
+[KeyQuest](https://github.com/hideyukiMORI/keyquest) is the full terminal typing adventure. It combines daily English typing practice with RPG-style progression, saved results, weak-key review, rewards, achievements, titles, resources, and localized UI/story messages.
+
+This GNU Typist lesson pack is a portable companion to that project. It does not include KeyQuest save data, scoring, story scenes, or reward systems. Instead, it preserves the curriculum shape and typing prompts in `.typ` files so the same practice path can be used inside gtypist.
 
 ## File Map
 


### PR DESCRIPTION
## Summary
- Clarify that the GNU Typist homepage is the official project URL and add local manual fallbacks.
- Add a short KeyQuest project introduction and repository link.
- Explain how this lesson pack relates to the full KeyQuest terminal adventure.

## Test plan
- Read the updated README and curriculum manual.
- Ran editor diagnostics for the edited markdown files.

Closes #8.

Made with [Cursor](https://cursor.com)